### PR TITLE
Implement sqlx macros for use in durable workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1022,6 +1022,7 @@ dependencies = [
  "durable",
  "durable-bindgen",
  "durable-core",
+ "durable-sqlx-macros",
  "futures-core",
  "futures-util",
  "log",
@@ -1031,6 +1032,16 @@ dependencies = [
  "thiserror",
  "url",
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "durable-sqlx-macros"
+version = "0.8.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-macros-core",
+ "syn",
 ]
 
 [[package]]
@@ -1054,6 +1065,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "durable",
+ "serde",
 ]
 
 [[package]]

--- a/crates/durable-sqlx-macros/Cargo.toml
+++ b/crates/durable-sqlx-macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "durable-sqlx-macros"
+edition = "2021"
+version = "0.8.0"
+license.workspace = true
+publish.workspace = true
+repository.workspace = true
+homepage.workspace = true
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.86"
+quote = "1.0.36"
+
+[dependencies.syn]
+version = "2.0.75"
+features = ["full", "parsing", "proc-macro", "visit-mut"]
+
+[dependencies.sqlx-macros-core]
+version = "0.8.0"
+features = ["macros", "postgres", "_rt-tokio"]

--- a/crates/durable-sqlx-macros/src/lib.rs
+++ b/crates/durable-sqlx-macros/src/lib.rs
@@ -1,0 +1,64 @@
+use proc_macro::TokenStream;
+use quote::ToTokens;
+use sqlx_macros_core::{query, FOSS_DRIVERS};
+
+#[proc_macro]
+pub fn expand_query(input: TokenStream) -> TokenStream {
+    let input = syn::parse_macro_input!(input as query::QueryMacroInput);
+
+    match query::expand_input(input, FOSS_DRIVERS) {
+        Ok(ts) => {
+            let mut expr: syn::Expr = match syn::parse2(ts) {
+                Ok(expr) => expr,
+                Err(e) => return e.to_compile_error().into(),
+            };
+
+            syn::visit_mut::visit_expr_mut(&mut Visitor, &mut expr);
+            // panic!("{expr:#?}");
+
+            expr.to_token_stream().into()
+        }
+        Err(e) => {
+            if let Some(parse_err) = e.downcast_ref::<syn::Error>() {
+                parse_err.to_compile_error().into()
+            } else {
+                let msg = e.to_string();
+                quote::quote!(::std::compile_error!(#msg)).into()
+            }
+        }
+    }
+}
+
+struct Visitor;
+
+impl syn::visit_mut::VisitMut for Visitor {
+    fn visit_path_mut(&mut self, path: &mut syn::Path) {
+        syn::visit_mut::visit_path_mut(self, path);
+
+        match path.segments.first() {
+            Some(segment) => {
+                if !segment.arguments.is_empty() {
+                    return;
+                }
+
+                if segment.ident != "sqlx" {
+                    return;
+                }
+            }
+            None => return,
+        }
+
+        path.leading_colon = None;
+    }
+
+    fn visit_item_use_mut(&mut self, item: &mut syn::ItemUse) {
+        syn::visit_mut::visit_item_use_mut(self, item);
+
+        match &mut item.tree {
+            syn::UseTree::Path(path) if path.ident == "sqlx" => (),
+            _ => return,
+        };
+
+        item.leading_colon = None;
+    }
+}

--- a/crates/durable-sqlx/Cargo.toml
+++ b/crates/durable-sqlx/Cargo.toml
@@ -10,9 +10,11 @@ description = "SQLx bindings for durable guests"
 
 [features]
 bindgen = ["dep:durable-bindgen", "durable-core/bindgen"]
+macros = ["durable-sqlx-macros", "sqlx/macros"]
 
 [dependencies]
 durable-core = { workspace = true }
+durable-sqlx-macros = { path = "../durable-sqlx-macros", optional = true }
 
 async-stream = "0.3.5"
 futures-core = "0.3.30"
@@ -29,4 +31,4 @@ thiserror = "1.0.63"
 durable-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
-durable = { workspace = true, features = ["sqlx"] }
+durable = { workspace = true, features = ["sqlx", "sqlx-macros"] }

--- a/crates/durable-sqlx/src/macros.rs
+++ b/crates/durable-sqlx/src/macros.rs
@@ -1,0 +1,231 @@
+pub mod exports {
+    pub use durable_sqlx_macros::expand_query;
+
+    use crate::driver::Durable;
+
+    pub mod sqlx {
+        pub use sqlx::*;
+
+        pub mod postgres {
+            pub use crate::driver::{Durable as Postgres, Row as PgRow};
+        }
+    }
+
+    pub fn map<'q, F, A>(map: sqlx::query::Map<'q, Durable, F, A>) -> crate::Map<'q, F, A> {
+        crate::Map(map)
+    }
+
+    pub fn scalar<'q, O, A>(
+        scalar: sqlx::query::QueryScalar<'q, Durable, O, A>,
+    ) -> crate::QueryScalar<'q, O, A> {
+        crate::QueryScalar(scalar)
+    }
+}
+
+/// Statically checked SQL query with `println!()` style syntax.
+///
+/// This is a thin wrapper around [`sqlx::query!`]. See the docs there for usage
+/// details.
+#[macro_export]
+macro_rules! query {
+    ($query:expr $(, $($args:tt)*)?) => {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::map($crate::exports::expand_query!(
+            source = $query
+            $(, args = [$($args)*])?
+        ))
+    }}
+}
+
+/// A variant of [`query!`] which does not check the input or output types. This
+/// still does parse the query to ensure it's syntactically and semantically
+/// valid for the current database.
+#[macro_export]
+macro_rules! query_unchecked {
+    ($query:expr $(, $($args:tt)*)?) => {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::map($crate::exports::expand_query!(
+            source = $query,
+            $(args = [$($args)*],)?
+            checked = false
+        ))
+    }}
+}
+
+/// A variant of [`query!`] where the SQL query is stored in a separate file.
+///
+/// Useful for large queries and potentially cleaner than multiline strings.
+///
+/// The syntax and requirements (see [`query!`]) are the same except the string
+/// is replaced by a file path.
+///
+/// The file must be relative to the project root (the directory containing
+/// `Cargo.toml`), unlike `include_str!()` which uses compiler internals to get
+/// the path of the file where it was invoked.
+#[macro_export]
+macro_rules! query_file {
+    ($path:literal $(, $($args:tt)*)?) => {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::map($crate::exports::expand_query!(
+            source_file = $path
+            $(, args = [$($args)*])?
+        ))
+    }}
+}
+
+/// A variant of [`query_file!`] which does not check the input or output types.
+///
+/// This still does parse the query to ensure it's syntactically and
+/// semantically valid for the current database.
+#[macro_export]
+macro_rules! query_file_unchecked {
+    ($path:literal $(, $($args:tt)*)?) => {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::map($crate::exports::expand_query!(
+            source_file = $path,
+            $(args = [$($args)*],)?
+            checked = false
+        ))
+    }}
+}
+
+/// A variant of [`query!`] which takes a path to an explicitly defined struct
+/// as the output type.
+///
+/// This is a wrapper around [`sqlx::query_as!`], see the docs there for more.
+#[macro_export]
+macro_rules! query_as {
+    ($out_struct:path, $query:expr $(, $($args:tt)*)?) => {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::map($crate::exports::expand_query!(
+            record = $out_struct,
+            source = $query
+            $(, args = [$($args)*])?
+        ))
+    }}
+}
+
+/// Combines the syntax of [`query_as!`] and [`query_file!`].
+///
+/// Enforces requirements of both macros; see them for details.
+#[macro_export]
+macro_rules! query_file_as {
+    ($out_struct:path, $path:literal $(, $($args:tt)*)?) => {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::map($crate::exports::expand_query!(
+            record = $out_struct,
+            source_file = $path
+            $(, args = [$($args)*])?
+        ))
+    }}
+}
+
+/// A variant of [`query_as!`] which does not check the input or output types.
+///
+/// This still does parse the query to ensure it's syntactically and
+/// semantically valid for the current database.
+#[macro_export]
+macro_rules! query_as_unchecked {
+    (out_struct:path, $query:expr $(, $($args:tt)*)?) => {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::map($crate::exports::expand_query!(
+            record = $out_struct,
+            source = $query,
+            $( args = [$($args)*],)?
+            checked = false
+        ))
+    }}
+}
+
+/// A variant of [`query_file_as!`] which does not check the input or output
+/// types.
+///
+/// This still does parse the query to ensure it's syntactically and
+/// semantically valid for the current database.
+#[macro_export]
+macro_rules! query_file_as_unchecked {
+    ($out_struct:path, $path:literal $(, $($args:tt)*)?) => {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::map($crate::exports::expand_query!(
+            record = $out_struct,
+            source_file = $path,
+            $(args = [$($args)*],)?
+            checked = false
+        ))
+    }}
+}
+
+/// A variant of [`query!`] which expects a single column from the query and
+/// evaluates to an instance of [`QueryScalar`](crate::QueryScalar).
+///
+/// See [`sqlx::query_scalar!`] for more details.
+#[macro_export]
+macro_rules! query_scalar {
+    ($query:expr $(, $($args:tt)*)?) =>  {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::scalar($crate::exports::expand_query!(
+            scalar = _,
+            source = $query
+            $(, args = [$($args)*])?
+        ))
+    }}
+}
+
+/// A variant of [`query_scalar!`] which takes a file path like [`query_file!`].
+#[macro_export]
+macro_rules! query_file_scalar {
+    ($path:literal $(,$($args:tt)*)?) => {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::scalar($crate::exports::expand_query!(
+            scalar = _,
+            source_file = $path
+            $(, args = [$($args)*])?
+        ))
+    }}
+}
+
+/// A variant of [`query_scalar!`] which does not typecheck bind parameters and
+/// leaves the output type to inference.
+///
+/// See [`sqlx::query_scalar_unchecked!`] for more details.
+#[macro_export]
+macro_rules! query_scalar_unchecked {
+    ($query:expr $(,$($args:tt)*)?) => {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::scalar($crate::exports::expand_query!(
+            scalar = _,
+            source = $query,
+            $(args = [$($args)*],)?
+            checked = false
+        ))
+    }}
+}
+
+/// A variant of [`query_file_scalar!`] which does not typecheck bind parameters
+/// and leaves the output type to inference.
+///
+/// See [`sqlx::query_scalar_unchecked!`] for more details.
+#[macro_export]
+macro_rules! query_file_scalar_unchecked {
+    ($path:literal $(,$($args:tt)*)?) => {{
+        use $crate::exports::sqlx;
+
+        $crate::exports::scalar($crate::exports::expand_query!(
+            scalar = _,
+            source_file = $path,
+            $(args = [$($args)*],)?
+            checked = false
+        ))
+    }}
+}

--- a/crates/durable-test-workflows/Cargo.toml
+++ b/crates/durable-test-workflows/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 test = false
 
 [dependencies]
-anyhow = "1.0"
+durable = { workspace = true, features = ["http", "sqlx", "sqlx-macros"] }
 
-durable = { workspace = true, features = ["http", "sqlx"] }
+anyhow = "1.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/durable-test-workflows/src/bin/sqlx-test-macros.rs
+++ b/crates/durable-test-workflows/src/bin/sqlx-test-macros.rs
@@ -1,0 +1,41 @@
+use durable::sqlx;
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct Record {
+    label: String,
+    value: String,
+}
+
+fn main() -> anyhow::Result<()> {
+    let task = durable::task();
+
+    println!("event log 1");
+    println!("event log 2");
+
+    let events = sqlx::transaction("get our task data", |mut conn| -> sqlx::Result<_> {
+        let events = sqlx::query_as!(
+            Record,
+            r#"
+            SELECT
+                label,
+                value::text as "value!"
+            FROM durable.event
+            WHERE task_id = $1
+            ORDER BY index ASC
+            "#,
+            task.id()
+        )
+        .fetch_all(&mut conn)?;
+
+        Ok(events)
+    })?;
+
+    for (idx, event) in events.iter().enumerate() {
+        println!("{idx:02}: {} - {}", event.label, event.value);
+    }
+
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0].label, "wasi:io/streams.output-stream.write");
+
+    Ok(())
+}

--- a/crates/durable/Cargo.toml
+++ b/crates/durable/Cargo.toml
@@ -13,6 +13,7 @@ default = []
 
 http = ["dep:durable-http"]
 sqlx = ["dep:durable-sqlx"]
+sqlx-macros = ["durable-sqlx?/macros"]
 
 bindgen = ["durable-core/bindgen", "durable-http?/bindgen", "durable-sqlx?/bindgen"]
 


### PR DESCRIPTION
This required some ugly hacks in order to map the output of the existing macros to the required types but it does work as expected now.