### PR TITLE
Add support for more sqlx array types

### DIFF
--- a/crates/durable-bindgen/src/lib.rs
+++ b/crates/durable-bindgen/src/lib.rs
@@ -13,7 +13,9 @@ impl Options {
         Self(Opts {
             format: true,
             runtime_path: Some("wit_bindgen_rt".into()),
-            ownership: Ownership::Owning,
+            ownership: Ownership::Borrowing {
+                duplicate_if_necessary: true,
+            },
             ..Default::default()
         })
     }

--- a/crates/durable-http/src/bindings.rs
+++ b/crates/durable-http/src/bindings.rs
@@ -9,30 +9,46 @@ pub mod durable {
             static __FORCE_SECTION_REF: fn() = super::super::super::__link_custom_section_describing_imports;
             use super::super::super::_rt;
             #[derive(Clone)]
-            pub struct HttpHeader {
+            pub struct HttpHeaderResult {
                 pub name: _rt::String,
                 pub value: _rt::Vec<u8>,
             }
-            impl ::core::fmt::Debug for HttpHeader {
+            impl ::core::fmt::Debug for HttpHeaderResult {
                 fn fmt(
                     &self,
                     f: &mut ::core::fmt::Formatter<'_>,
                 ) -> ::core::fmt::Result {
-                    f.debug_struct("HttpHeader")
+                    f.debug_struct("HttpHeaderResult")
                         .field("name", &self.name)
                         .field("value", &self.value)
                         .finish()
                 }
             }
             #[derive(Clone)]
-            pub struct HttpRequest {
-                pub method: _rt::String,
-                pub url: _rt::String,
-                pub headers: _rt::Vec<HttpHeader>,
-                pub body: Option<_rt::Vec<u8>>,
+            pub struct HttpHeaderParam<'a> {
+                pub name: &'a str,
+                pub value: &'a [u8],
+            }
+            impl<'a> ::core::fmt::Debug for HttpHeaderParam<'a> {
+                fn fmt(
+                    &self,
+                    f: &mut ::core::fmt::Formatter<'_>,
+                ) -> ::core::fmt::Result {
+                    f.debug_struct("HttpHeaderParam")
+                        .field("name", &self.name)
+                        .field("value", &self.value)
+                        .finish()
+                }
+            }
+            #[derive(Clone)]
+            pub struct HttpRequest<'a> {
+                pub method: &'a str,
+                pub url: &'a str,
+                pub headers: &'a [HttpHeaderParam<'a>],
+                pub body: Option<&'a [u8]>,
                 pub timeout: Option<u64>,
             }
-            impl ::core::fmt::Debug for HttpRequest {
+            impl<'a> ::core::fmt::Debug for HttpRequest<'a> {
                 fn fmt(
                     &self,
                     f: &mut ::core::fmt::Formatter<'_>,
@@ -49,7 +65,7 @@ pub mod durable {
             #[derive(Clone)]
             pub struct HttpResponse {
                 pub status: u16,
-                pub headers: _rt::Vec<HttpHeader>,
+                pub headers: _rt::Vec<HttpHeaderResult>,
                 pub body: _rt::Vec<u8>,
             }
             impl ::core::fmt::Debug for HttpResponse {
@@ -114,7 +130,7 @@ pub mod durable {
             ///
             /// # Parameters
             /// - `request` - A description of the HTTP request to make.
-            pub fn fetch(request: &HttpRequest) -> Result<HttpResponse, HttpError> {
+            pub fn fetch(request: HttpRequest<'_>) -> Result<HttpResponse, HttpError> {
                 unsafe {
                     #[repr(align(4))]
                     struct RetArea([::core::mem::MaybeUninit<u8>; 24]);
@@ -150,7 +166,7 @@ pub mod durable {
                     for (i, e) in vec6.into_iter().enumerate() {
                         let base = result6.add(i * 16);
                         {
-                            let HttpHeader { name: name3, value: value3 } = e;
+                            let HttpHeaderParam { name: name3, value: value3 } = e;
                             let vec4 = name3;
                             let ptr4 = vec4.as_ptr().cast::<u8>();
                             let len4 = vec4.len();
@@ -254,7 +270,7 @@ pub mod durable {
                                         let l18 = *base.add(8).cast::<*mut u8>();
                                         let l19 = *base.add(12).cast::<usize>();
                                         let len20 = l19;
-                                        HttpHeader {
+                                        HttpHeaderResult {
                                             name: _rt::string_lift(bytes17),
                                             value: _rt::Vec::from_raw_parts(l18.cast(), len20, len20),
                                         }

--- a/crates/durable-sqlx/src/bindings.rs
+++ b/crates/durable-sqlx/src/bindings.rs
@@ -3093,7 +3093,7 @@ pub mod durable {
             }
             impl Value {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn text_array(value: &[_rt::String]) -> Value {
+                pub fn text_array(value: &[&str]) -> Value {
                     unsafe {
                         let vec1 = value;
                         let len1 = vec1.len();
@@ -3140,7 +3140,7 @@ pub mod durable {
             }
             impl Value {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn bytea_array(value: &[_rt::Vec<u8>]) -> Value {
+                pub fn bytea_array(value: &[&[u8]]) -> Value {
                     unsafe {
                         let vec1 = value;
                         let len1 = vec1.len();
@@ -3253,7 +3253,7 @@ pub mod durable {
             }
             impl Value {
                 #[allow(unused_unsafe, clippy::all)]
-                pub fn jsonb_array(value: &[_rt::String]) -> Value {
+                pub fn jsonb_array(value: &[&str]) -> Value {
                     unsafe {
                         let vec1 = value;
                         let len1 = vec1.len();

--- a/crates/durable-sqlx/src/driver/types/boolean.rs
+++ b/crates/durable-sqlx/src/driver/types/boolean.rs
@@ -1,15 +1,16 @@
 use sqlx::encode::IsNull;
+use sqlx::error::BoxDynError;
 
 use super::unexpected_nonnull_type;
 use crate::bindings::durable::core::sql;
 use crate::driver::{TypeInfo, Value};
-use crate::{BoxDynError, Durable};
+use crate::Durable;
 
 impl sqlx::Decode<'_, Durable> for bool {
     fn decode(value: <Durable as sqlx::Database>::ValueRef<'_>) -> Result<Self, BoxDynError> {
         match value.0.as_boolean() {
             Some(v) => Ok(v),
-            _ => Err(unexpected_nonnull_type("bool", value)),
+            _ => Err(unexpected_nonnull_type(&TypeInfo::boolean(), value)),
         }
     }
 }
@@ -18,7 +19,7 @@ impl sqlx::Encode<'_, Durable> for bool {
     fn encode_by_ref(
         &self,
         buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, sqlx::error::BoxDynError> {
+    ) -> Result<IsNull, BoxDynError> {
         buf.push(Value::new(sql::Value::boolean(*self)));
         Ok(IsNull::No)
     }
@@ -30,27 +31,4 @@ impl sqlx::Type<Durable> for bool {
     }
 }
 
-impl sqlx::Decode<'_, Durable> for Vec<bool> {
-    fn decode(value: <Durable as sqlx::Database>::ValueRef<'_>) -> Result<Self, BoxDynError> {
-        match value.0.as_boolean_array() {
-            Some(v) => Ok(v),
-            _ => Err(unexpected_nonnull_type("bool[]", value)),
-        }
-    }
-}
-
-impl sqlx::Encode<'_, Durable> for Vec<bool> {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, BoxDynError> {
-        buf.push(Value::new(sql::Value::boolean_array(self)));
-        Ok(IsNull::No)
-    }
-}
-
-impl sqlx::Type<Durable> for Vec<bool> {
-    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
-        TypeInfo::boolean_array()
-    }
-}
+generic_slice_decl!(bool => boolean boolean_array as_boolean_array);

--- a/crates/durable-sqlx/src/driver/types/bytea.rs
+++ b/crates/durable-sqlx/src/driver/types/bytea.rs
@@ -3,26 +3,11 @@ use std::borrow::Cow;
 use sqlx::encode::IsNull;
 use sqlx::error::BoxDynError;
 
-use super::unexpected_nonnull_type;
+use super::{encode_by_ref, unexpected_nonnull_type};
 use crate::driver::{TypeInfo, Value};
 use crate::{bindings as sql, Durable};
 
-impl<'r> sqlx::Decode<'r, Durable> for Cow<'_, [u8]> {
-    fn decode(value: <Durable as sqlx::Database>::ValueRef<'r>) -> Result<Self, BoxDynError> {
-        <Vec<u8> as sqlx::Decode<Durable>>::decode(value).map(Cow::Owned)
-    }
-}
-
-impl sqlx::Decode<'_, Durable> for Vec<u8> {
-    fn decode(value: <Durable as sqlx::Database>::ValueRef<'_>) -> Result<Self, BoxDynError> {
-        match value.0.as_bytea() {
-            Some(bytes) => Ok(bytes),
-            None => Err(unexpected_nonnull_type("bytea", value)),
-        }
-    }
-}
-
-impl sqlx::Encode<'_, Durable> for &[u8] {
+impl sqlx::Encode<'_, Durable> for [u8] {
     fn encode_by_ref(
         &self,
         buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
@@ -32,30 +17,17 @@ impl sqlx::Encode<'_, Durable> for &[u8] {
     }
 }
 
+forward_encode_deref!(&'_ [u8] => [u8]);
+forward_encode_deref!(Vec<u8> => [u8]);
+forward_encode_deref!(Box<[u8]> => [u8]);
+forward_encode_deref!(Cow<'_, [u8]> => [u8]);
+
 impl<const N: usize> sqlx::Encode<'_, Durable> for [u8; N] {
     fn encode_by_ref(
         &self,
         buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
     ) -> Result<IsNull, sqlx::error::BoxDynError> {
-        <&[u8] as sqlx::Encode<Durable>>::encode(self, buf)
-    }
-}
-
-impl sqlx::Encode<'_, Durable> for Box<[u8]> {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, sqlx::error::BoxDynError> {
-        <&[u8] as sqlx::Encode<Durable>>::encode(self, buf)
-    }
-}
-
-impl sqlx::Encode<'_, Durable> for Vec<u8> {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, sqlx::error::BoxDynError> {
-        <&[u8] as sqlx::Encode<Durable>>::encode(self, buf)
+        encode_by_ref::<[u8]>(self, buf)
     }
 }
 
@@ -65,17 +37,9 @@ impl sqlx::Type<Durable> for Vec<u8> {
     }
 }
 
-impl sqlx::Type<Durable> for Cow<'_, [u8]> {
-    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
-        <Vec<u8> as sqlx::Type<Durable>>::type_info()
-    }
-}
-
-impl sqlx::Type<Durable> for Box<[u8]> {
-    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
-        <Vec<u8> as sqlx::Type<Durable>>::type_info()
-    }
-}
+forward_type!([u8] => Vec<u8>);
+forward_type!(Box<[u8]> => Vec<u8>);
+forward_type!(Cow<'_, [u8]> => Vec<u8>);
 
 impl<const N: usize> sqlx::Type<Durable> for [u8; N] {
     fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
@@ -83,7 +47,7 @@ impl<const N: usize> sqlx::Type<Durable> for [u8; N] {
     }
 }
 
-impl sqlx::Encode<'_, Durable> for Vec<Vec<u8>> {
+impl sqlx::Encode<'_, Durable> for [&[u8]] {
     fn encode_by_ref(
         &self,
         buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
@@ -93,21 +57,24 @@ impl sqlx::Encode<'_, Durable> for Vec<Vec<u8>> {
     }
 }
 
-impl sqlx::Encode<'_, Durable> for &'_ [Vec<u8>] {
+impl sqlx::Encode<'_, Durable> for [Vec<u8>] {
     fn encode_by_ref(
         &self,
         buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
     ) -> Result<IsNull, BoxDynError> {
-        buf.push(Value::new(sql::Value::bytea_array(self)));
-        Ok(IsNull::No)
+        let vec: Vec<_> = self.iter().map(|x| &x[..]).collect();
+        encode_by_ref::<[&[u8]]>(&vec, buf)
     }
 }
+
+forward_slice_encode_deref!(&'_ [u8]);
+forward_slice_encode_deref!(Vec<u8>);
 
 impl sqlx::Decode<'_, Durable> for Vec<Vec<u8>> {
     fn decode(value: <Durable as sqlx::Database>::ValueRef<'_>) -> Result<Self, BoxDynError> {
         match value.0.as_bytea_array() {
             Some(value) => Ok(value),
-            None => Err(unexpected_nonnull_type("bytea[]", value)),
+            None => Err(unexpected_nonnull_type(&TypeInfo::bytea_array(), value)),
         }
     }
 }
@@ -117,3 +84,7 @@ impl sqlx::Type<Durable> for Vec<Vec<u8>> {
         TypeInfo::bytea_array()
     }
 }
+
+forward_type!(Vec<&'_ [u8]> => Vec<Vec<u8>>);
+forward_slice_type!(&'_ [u8]);
+forward_slice_type!(Vec<u8>);

--- a/crates/durable-sqlx/src/driver/types/chrono.rs
+++ b/crates/durable-sqlx/src/driver/types/chrono.rs
@@ -22,7 +22,7 @@ impl sqlx::Decode<'_, Durable> for DateTime<FixedOffset> {
             return Ok(ts.into());
         }
 
-        Err(unexpected_nonnull_type("timestamptz", value))
+        Err(unexpected_nonnull_type(&TypeInfo::timestamptz(), value))
     }
 }
 
@@ -61,7 +61,7 @@ impl sqlx::Decode<'_, Durable> for NaiveDateTime {
             return Ok(ts.into());
         }
 
-        Err(unexpected_nonnull_type("timestamp", value))
+        Err(unexpected_nonnull_type(&TypeInfo::timestamp(), value))
     }
 }
 
@@ -99,7 +99,10 @@ impl sqlx::Decode<'_, Durable> for Vec<DateTime<FixedOffset>> {
             return Ok(values);
         }
 
-        Err(unexpected_nonnull_type("timestamptz[]", value))
+        Err(unexpected_nonnull_type(
+            &TypeInfo::timestamptz_array(),
+            value,
+        ))
     }
 }
 
@@ -114,7 +117,10 @@ impl sqlx::Decode<'_, Durable> for Vec<DateTime<Utc>> {
             return Ok(values);
         }
 
-        Err(unexpected_nonnull_type("timestamptz[]", value))
+        Err(unexpected_nonnull_type(
+            &TypeInfo::timestamptz_array(),
+            value,
+        ))
     }
 }
 
@@ -129,7 +135,10 @@ impl sqlx::Decode<'_, Durable> for Vec<DateTime<Local>> {
             return Ok(values);
         }
 
-        Err(unexpected_nonnull_type("timestamptz[]", value))
+        Err(unexpected_nonnull_type(
+            &TypeInfo::timestamptz_array(),
+            value,
+        ))
     }
 }
 
@@ -173,7 +182,7 @@ impl sqlx::Decode<'_, Durable> for Vec<NaiveDateTime> {
             return Ok(values);
         }
 
-        Err(unexpected_nonnull_type("timestamp[]", value))
+        Err(unexpected_nonnull_type(&TypeInfo::timestamp_array(), value))
     }
 }
 

--- a/crates/durable-sqlx/src/driver/types/float.rs
+++ b/crates/durable-sqlx/src/driver/types/float.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use sqlx::encode::IsNull;
 use sqlx::error::BoxDynError;
 
@@ -27,7 +25,7 @@ impl sqlx::Decode<'_, Durable> for f32 {
             return Ok(v as f32);
         }
 
-        Err(unexpected_nonnull_type("float4", value))
+        Err(unexpected_nonnull_type(&TypeInfo::float4(), value))
     }
 }
 
@@ -51,7 +49,7 @@ impl sqlx::Decode<'_, Durable> for f64 {
             return Ok(v);
         }
 
-        Err(unexpected_nonnull_type("float8", value))
+        Err(unexpected_nonnull_type(&TypeInfo::float8(), value))
     }
 }
 
@@ -67,144 +65,5 @@ impl sqlx::Type<Durable> for f64 {
     }
 }
 
-impl sqlx::Encode<'_, Durable> for &'_ [f32] {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, BoxDynError> {
-        buf.push(Value::new(sql::Value::float4_array(self)));
-        Ok(IsNull::No)
-    }
-}
-
-impl sqlx::Encode<'_, Durable> for Vec<f32> {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, BoxDynError> {
-        <&[f32] as sqlx::Encode<Durable>>::encode(self, buf)
-    }
-}
-
-impl sqlx::Encode<'_, Durable> for Box<[f32]> {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, BoxDynError> {
-        <&[f32] as sqlx::Encode<Durable>>::encode(self, buf)
-    }
-}
-
-impl sqlx::Encode<'_, Durable> for Cow<'_, [f32]> {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, BoxDynError> {
-        <&[f32] as sqlx::Encode<Durable>>::encode(self, buf)
-    }
-}
-
-impl sqlx::Decode<'_, Durable> for Vec<f32> {
-    fn decode(value: <Durable as sqlx::Database>::ValueRef<'_>) -> Result<Self, BoxDynError> {
-        if let Some(value) = value.0.as_float4_array() {
-            return Ok(value);
-        }
-
-        Err(unexpected_nonnull_type("float4[]", value))
-    }
-}
-
-impl sqlx::Type<Durable> for &'_ [f32] {
-    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
-        <Vec<f32> as sqlx::Type<Durable>>::type_info()
-    }
-}
-
-impl sqlx::Type<Durable> for Vec<f32> {
-    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
-        TypeInfo::float4_array()
-    }
-}
-
-impl sqlx::Type<Durable> for Box<[f32]> {
-    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
-        <Vec<f32> as sqlx::Type<Durable>>::type_info()
-    }
-}
-
-impl sqlx::Type<Durable> for Cow<'_, [f32]> {
-    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
-        <Vec<f32> as sqlx::Type<Durable>>::type_info()
-    }
-}
-
-impl sqlx::Encode<'_, Durable> for &'_ [f64] {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, BoxDynError> {
-        buf.push(Value::new(sql::Value::float8_array(self)));
-        Ok(IsNull::No)
-    }
-}
-
-impl sqlx::Encode<'_, Durable> for Vec<f64> {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, BoxDynError> {
-        <&[f64] as sqlx::Encode<Durable>>::encode(self, buf)
-    }
-}
-
-impl sqlx::Encode<'_, Durable> for Box<[f64]> {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, BoxDynError> {
-        <&[f64] as sqlx::Encode<Durable>>::encode(self, buf)
-    }
-}
-
-impl sqlx::Encode<'_, Durable> for Cow<'_, [f64]> {
-    fn encode_by_ref(
-        &self,
-        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
-    ) -> Result<IsNull, BoxDynError> {
-        <&[f64] as sqlx::Encode<Durable>>::encode(self, buf)
-    }
-}
-
-impl sqlx::Decode<'_, Durable> for Vec<f64> {
-    fn decode(value: <Durable as sqlx::Database>::ValueRef<'_>) -> Result<Self, BoxDynError> {
-        if let Some(value) = value.0.as_float8_array() {
-            return Ok(value);
-        }
-
-        Err(unexpected_nonnull_type("float8[]", value))
-    }
-}
-
-impl sqlx::Type<Durable> for &'_ [f64] {
-    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
-        <Vec<f64> as sqlx::Type<Durable>>::type_info()
-    }
-}
-
-impl sqlx::Type<Durable> for Vec<f64> {
-    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
-        TypeInfo::float8_array()
-    }
-}
-
-impl sqlx::Type<Durable> for Box<[f64]> {
-    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
-        <Vec<f64> as sqlx::Type<Durable>>::type_info()
-    }
-}
-
-impl sqlx::Type<Durable> for Cow<'_, [f64]> {
-    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
-        <Vec<f32> as sqlx::Type<Durable>>::type_info()
-    }
-}
+generic_slice_decl!(f32 => float4_array float4_array as_float4_array);
+generic_slice_decl!(f64 => float8_array float8_array as_float8_array);

--- a/crates/durable-sqlx/src/driver/types/int.rs
+++ b/crates/durable-sqlx/src/driver/types/int.rs
@@ -63,7 +63,7 @@ fn decode_int(value: &Value) -> Result<i64, BoxDynError> {
         return Ok(v);
     }
 
-    Err(unexpected_nonnull_type("integer", value))
+    Err(unexpected_nonnull_type(&TypeInfo::int8(), value))
 }
 
 impl Decode<'_, Durable> for i8 {
@@ -119,3 +119,8 @@ impl sqlx::Type<Durable> for i64 {
         TypeInfo::int8()
     }
 }
+
+generic_slice_decl!(i8  => int1_array int1_array as_int1_array);
+generic_slice_decl!(i16 => int2_array int2_array as_int2_array);
+generic_slice_decl!(i32 => int4_array int4_array as_int4_array);
+generic_slice_decl!(i64 => int8_array int8_array as_int8_array);

--- a/crates/durable-sqlx/src/driver/types/ipnetwork.rs
+++ b/crates/durable-sqlx/src/driver/types/ipnetwork.rs
@@ -42,7 +42,7 @@ impl sqlx::Decode<'_, Durable> for IpNetwork {
             return Ok(inet.try_into()?);
         }
 
-        Err(unexpected_nonnull_type("inet", value))
+        Err(unexpected_nonnull_type(&TypeInfo::inet(), value))
     }
 }
 

--- a/crates/durable-sqlx/src/driver/types/mod.rs
+++ b/crates/durable-sqlx/src/driver/types/mod.rs
@@ -1,7 +1,86 @@
+use sqlx::encode::IsNull;
 use sqlx::error::BoxDynError;
 use sqlx::Value as _;
 
+use super::{Durable, TypeInfo};
 use crate::driver::Value;
+
+macro_rules! generic_slice_decl {
+    ($type:ty => $tyinfo:ident $ctor:ident $as_method:ident) => {
+        impl<'q> sqlx::Encode<'q, Durable> for [$type] {
+            fn encode_by_ref(
+                &self,
+                buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'q>,
+            ) -> Result<IsNull, BoxDynError> {
+                buf.push(Value::new(sql::Value::$ctor(self)));
+                Ok(IsNull::No)
+            }
+        }
+
+        impl<'q> sqlx::Decode<'q, Durable> for Vec<$type> {
+            fn decode(
+                value: <Durable as sqlx::Database>::ValueRef<'q>,
+            ) -> Result<Self, BoxDynError> {
+                if let Some(value) = value.0.$as_method() {
+                    return Ok(value);
+                }
+
+                Err(unexpected_nonnull_type(
+                    &<Self as sqlx::Type<Durable>>::type_info(),
+                    value,
+                ))
+            }
+        }
+
+        impl sqlx::Type<Durable> for Vec<$type> {
+            fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
+                <Durable as sqlx::Database>::TypeInfo::$tyinfo()
+            }
+        }
+
+        forward_slice_encode_deref!($type);
+        forward_slice_type!($type);
+    };
+}
+
+macro_rules! forward_encode_deref {
+    ($type:ty => $target:ty) => {
+        impl<'q> sqlx::Encode<'q, Durable> for $type {
+            fn encode_by_ref(
+                &self,
+                buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'q>,
+            ) -> Result<IsNull, BoxDynError> {
+                <$target as sqlx::Encode<'q, Durable>>::encode_by_ref(self, buf)
+            }
+        }
+    };
+}
+macro_rules! forward_slice_encode_deref {
+    ($elem:ty) => {
+        forward_encode_deref!(&'_ [$elem] => [$elem]);
+        forward_encode_deref!(Vec<$elem> => [$elem]);
+        forward_encode_deref!(Box<[$elem]> => [$elem]);
+        forward_encode_deref!(std::borrow::Cow<'_, [$elem]> => [$elem]);
+    }
+}
+
+macro_rules! forward_type {
+    ($type:ty => $target:ty) => {
+        impl sqlx::Type<Durable> for $type {
+            fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
+                <$target as sqlx::Type<Durable>>::type_info()
+            }
+        }
+    };
+}
+
+macro_rules! forward_slice_type {
+    ($elem:ty) => {
+        forward_type!([$elem] => Vec<$elem>);
+        forward_type!(Box<[$elem]> => Vec<$elem>);
+        forward_type!(std::borrow::Cow<'_, [$elem]> => Vec<$elem>);
+    }
+}
 
 mod boolean;
 mod bytea;
@@ -17,14 +96,24 @@ mod text;
 #[cfg(feature = "uuid")]
 mod uuid;
 
-fn unexpected_nullable_type(expected: &str, value: &Value) -> BoxDynError {
+fn unexpected_nullable_type(expected: &TypeInfo, value: &Value) -> BoxDynError {
     format!("expected {expected}, got {} instead", value.type_info()).into()
 }
 
-fn unexpected_nonnull_type(expected: &str, value: &Value) -> BoxDynError {
+fn unexpected_nonnull_type(expected: &TypeInfo, value: &Value) -> BoxDynError {
     if value.is_null() {
         return format!("expected non-null {expected}, got null instead").into();
     }
 
     unexpected_nullable_type(expected, value)
+}
+
+fn encode_by_ref<'q, T>(
+    value: &T,
+    buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'q>,
+) -> Result<IsNull, BoxDynError>
+where
+    T: sqlx::Encode<'q, Durable> + ?Sized,
+{
+    value.encode_by_ref(buf)
 }


### PR DESCRIPTION
We were missing implementations of sqlx::Encode, sqlx::Decode, and sqlx::Type for a bunch of different array types.

This commit uses some macros to make stamping out the required impls easy and then does so for all the available types.