### PR TITLE
Add config option to control the number of concurrent compilations

### DIFF
--- a/crates/durable-runtime/src/config.rs
+++ b/crates/durable-runtime/src/config.rs
@@ -4,6 +4,7 @@ use derive_setters::Setters;
 
 /// Config options controlling the behaviour of this worker.
 #[derive(Clone, Debug, Setters)]
+#[non_exhaustive]
 pub struct Config {
     /// The period with which the worker will update its heartbeat timestamp in
     /// the database.
@@ -104,6 +105,19 @@ pub struct Config {
     ///
     /// The default limit is 2000 tasks.
     pub max_tasks: usize,
+
+    /// The maximum number of WASM binaries that can be compiled concurrently.
+    ///
+    /// Compiling WASM down to machine code is moderately expensive (e.g. a
+    /// decent sized module can take 300ms to compile) so if a worker has to
+    /// build it can use up all the available cores and memory on a machine.
+    ///
+    /// Note that, once compiled, the resulting machine code is cached so if the
+    /// same WASM binary is encountered multiple times then the compiled code
+    /// will be reused.
+    /// 
+    /// The default limit is 4 concurrent compilation tasks.
+    pub max_concurrent_compilations: usize,
 }
 
 impl Config {
@@ -125,6 +139,7 @@ impl Default for Config {
             suspend_timeout: Duration::from_secs(60),
             suspend_margin: Duration::from_secs(10),
             max_tasks: 1000,
+            max_concurrent_compilations: 4,
         }
     }
 }

--- a/crates/durable-runtime/src/config.rs
+++ b/crates/durable-runtime/src/config.rs
@@ -115,7 +115,7 @@ pub struct Config {
     /// Note that, once compiled, the resulting machine code is cached so if the
     /// same WASM binary is encountered multiple times then the compiled code
     /// will be reused.
-    /// 
+    ///
     /// The default limit is 4 concurrent compilation tasks.
     pub max_concurrent_compilations: usize,
 }

--- a/crates/durable-runtime/src/lib.rs
+++ b/crates/durable-runtime/src/lib.rs
@@ -1,3 +1,5 @@
+//! The worker and runtime responsible for executing durable tasks.
+
 #[macro_use]
 extern crate serde;
 

--- a/crates/durable-runtime/src/worker.rs
+++ b/crates/durable-runtime/src/worker.rs
@@ -155,15 +155,15 @@ impl WorkerBuilder {
 
         let shared = Arc::new(SharedState {
             shutdown: ShutdownFlag::new(),
-            pool: self.pool,
             client: self.client.unwrap_or_default(),
             notifications: broadcast::channel(128).0,
-            config: self.config,
-            plugins: self.plugins,
             leader: Mailbox::new(-1),
             suspend: Notify::new(),
             cache: Mutex::new(uluru::LRUCache::new()),
-            compile_sema: Semaphore::new(4),
+            compile_sema: Semaphore::new(self.config.max_concurrent_compilations),
+            pool: self.pool,
+            config: self.config,
+            plugins: self.plugins,
         });
 
         let mut config = self.wasmtime_config.unwrap_or_else(|| {


### PR DESCRIPTION
This was hardcoded before but there is really no reason to require it to be hardcoded.