### PR TITLE
Rework worker liveness checks

### DIFF
--- a/crates/xtask/src/dev.rs
+++ b/crates/xtask/src/dev.rs
@@ -38,6 +38,8 @@ impl Dev {
         command.arg("-e");
         command.arg("POSTGRES_HOST_AUTH_METHOD=trust");
         command.arg("--rm");
+        command.arg("--shm-size");
+        command.arg("4GB");
         command.arg("--name");
         command.arg("durable-postgres");
 


### PR DESCRIPTION
The previous way that liveness checks happened is that workers would periodically check all other workers to see if any of them had failed to update their heartbeat recently. The period that each individual worker would actually check at is proportional to the number of workers that are present.

This becomes a problem when the number of workers available changes quickly since the remaining workers may take a long time to actually run another liveness check. By giving each worker the responsibility for monitoring one other worker we can ensure that dead workers are removed immediately after they expire. This will still take a while to work through things if large numbers of workers die, but should otherwise be ok.