### PR TITLE
Make the http-error type a resource so it can be modified in the future

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1002,6 +1002,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uluru",
+ "url",
  "uuid",
  "wasmtime",
  "wasmtime-wit-bindgen",

--- a/crates/durable-core/src/bindings.rs
+++ b/crates/durable-core/src/bindings.rs
@@ -13,7 +13,7 @@ pub mod durable {
             pub fn task_id() -> i64 {
                 unsafe {
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/core@2.3.0")]
+                    #[link(wasm_import_module = "durable:core/core@2.4.0")]
                     extern "C" {
                         #[link_name = "task-id"]
                         fn wit_import() -> i64;
@@ -35,7 +35,7 @@ pub mod durable {
                     let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 8]);
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/core@2.3.0")]
+                    #[link(wasm_import_module = "durable:core/core@2.4.0")]
                     extern "C" {
                         #[link_name = "task-name"]
                         fn wit_import(_: *mut u8);
@@ -61,7 +61,7 @@ pub mod durable {
                     let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 8]);
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/core@2.3.0")]
+                    #[link(wasm_import_module = "durable:core/core@2.4.0")]
                     extern "C" {
                         #[link_name = "task-data"]
                         fn wit_import(_: *mut u8);
@@ -98,7 +98,7 @@ pub mod durable {
                     let len0 = vec0.len();
                     let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/core@2.3.0")]
+                    #[link(wasm_import_module = "durable:core/core@2.4.0")]
                     extern "C" {
                         #[link_name = "transaction-enter"]
                         fn wit_import(_: *mut u8, _: usize, _: i32, _: *mut u8);
@@ -148,7 +148,7 @@ pub mod durable {
                     let ptr0 = vec0.as_ptr().cast::<u8>();
                     let len0 = vec0.len();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/core@2.3.0")]
+                    #[link(wasm_import_module = "durable:core/core@2.4.0")]
                     extern "C" {
                         #[link_name = "transaction-exit"]
                         fn wit_import(_: *mut u8, _: usize);
@@ -238,7 +238,7 @@ pub mod durable {
                     let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 32]);
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/notify@2.3.0")]
+                    #[link(wasm_import_module = "durable:core/notify@2.4.0")]
                     extern "C" {
                         #[link_name = "notification-blocking"]
                         fn wit_import(_: *mut u8);
@@ -287,7 +287,7 @@ pub mod durable {
                     let len1 = vec1.len();
                     let ptr2 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/notify@2.3.0")]
+                    #[link(wasm_import_module = "durable:core/notify@2.4.0")]
                     extern "C" {
                         #[link_name = "notify"]
                         fn wit_import(
@@ -505,15 +505,15 @@ pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 665] = *b"\
 A\x07\x01B\x0a\x01@\0\0x\x04\0\x07task-id\x01\0\x01@\0\0s\x04\0\x09task-name\x01\
 \x01\x04\0\x09task-data\x01\x01\x01ks\x01@\x02\x05labels\x05is-db\x7f\0\x02\x04\0\
 \x11transaction-enter\x01\x03\x01@\x01\x04datas\x01\0\x04\0\x10transaction-exit\x01\
-\x04\x03\x01\x17durable:core/core@2.3.0\x05\0\x01B\x05\x01r\x02\x07secondsw\x0bn\
+\x04\x03\x01\x17durable:core/core@2.4.0\x05\0\x01B\x05\x01r\x02\x07secondsw\x0bn\
 anosecondsy\x04\0\x08datetime\x03\0\0\x01@\0\0\x01\x04\0\x03now\x01\x02\x04\0\x0a\
 resolution\x01\x02\x03\x01\x1cwasi:clocks/wall-clock@0.2.0\x05\x01\x02\x03\0\x01\
 \x08datetime\x01B\x0b\x02\x03\x02\x01\x02\x04\0\x08datetime\x03\0\0\x01r\x03\x0a\
 created-at\x01\x05events\x04datas\x04\0\x05event\x03\0\x02\x01q\x03\x0etask-not-\
 found\0\0\x09task-dead\0\0\x05other\x01s\0\x04\0\x0cnotify-error\x03\0\x04\x01@\0\
 \0\x03\x04\0\x15notification-blocking\x01\x06\x01j\0\x01\x05\x01@\x03\x04taskx\x05\
-events\x04datas\0\x07\x04\0\x06notify\x01\x08\x03\x01\x19durable:core/notify@2.3\
-.0\x05\x03\x04\x01\x1edurable:core/import-core@2.3.0\x04\0\x0b\x11\x01\0\x0bimpo\
+events\x04datas\0\x07\x04\0\x06notify\x01\x08\x03\x01\x19durable:core/notify@2.4\
+.0\x05\x03\x04\x01\x1edurable:core/import-core@2.4.0\x04\0\x0b\x11\x01\0\x0bimpo\
 rt-core\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.21\
 5.0\x10wit-bindgen-rust\x060.30.0";
 #[inline(never)]

--- a/crates/durable-http/src/bindings.rs
+++ b/crates/durable-http/src/bindings.rs
@@ -125,6 +125,83 @@ pub mod durable {
                 }
             }
             impl std::error::Error for HttpError {}
+            #[derive(Debug)]
+            #[repr(transparent)]
+            pub struct HttpError2 {
+                handle: _rt::Resource<HttpError2>,
+            }
+            impl HttpError2 {
+                #[doc(hidden)]
+                pub unsafe fn from_handle(handle: u32) -> Self {
+                    Self {
+                        handle: _rt::Resource::from_handle(handle),
+                    }
+                }
+                #[doc(hidden)]
+                pub fn take_handle(&self) -> u32 {
+                    _rt::Resource::take_handle(&self.handle)
+                }
+                #[doc(hidden)]
+                pub fn handle(&self) -> u32 {
+                    _rt::Resource::handle(&self.handle)
+                }
+            }
+            unsafe impl _rt::WasmResource for HttpError2 {
+                #[inline]
+                unsafe fn drop(_handle: u32) {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unreachable!();
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[resource-drop]http-error2"]
+                            fn drop(_: u32);
+                        }
+                        drop(_handle);
+                    }
+                }
+            }
+            /// A HTTP request.
+            ///
+            /// In order to actually make the request you will need to call `fetch2`.
+            #[derive(Debug)]
+            #[repr(transparent)]
+            pub struct HttpRequest2 {
+                handle: _rt::Resource<HttpRequest2>,
+            }
+            impl HttpRequest2 {
+                #[doc(hidden)]
+                pub unsafe fn from_handle(handle: u32) -> Self {
+                    Self {
+                        handle: _rt::Resource::from_handle(handle),
+                    }
+                }
+                #[doc(hidden)]
+                pub fn take_handle(&self) -> u32 {
+                    _rt::Resource::take_handle(&self.handle)
+                }
+                #[doc(hidden)]
+                pub fn handle(&self) -> u32 {
+                    _rt::Resource::handle(&self.handle)
+                }
+            }
+            unsafe impl _rt::WasmResource for HttpRequest2 {
+                #[inline]
+                unsafe fn drop(_handle: u32) {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    unreachable!();
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[resource-drop]http-request2"]
+                            fn drop(_: u32);
+                        }
+                        drop(_handle);
+                    }
+                }
+            }
             #[allow(unused_unsafe, clippy::all)]
             /// Make an HTTP request.
             ///
@@ -194,7 +271,7 @@ pub mod durable {
                     };
                     let ptr10 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/http@2.3.0")]
+                    #[link(wasm_import_module = "durable:core/http@2.4.0")]
                     extern "C" {
                         #[link_name = "fetch"]
                         fn wit_import(
@@ -335,12 +412,546 @@ pub mod durable {
                     }
                 }
             }
+            impl HttpError2 {
+                #[allow(unused_unsafe, clippy::all)]
+                /// The error message describing what went wrong.
+                pub fn message(&self) -> _rt::String {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 8]);
+                        let mut ret_area = RetArea(
+                            [::core::mem::MaybeUninit::uninit(); 8],
+                        );
+                        let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[method]http-error2.message"]
+                            fn wit_import(_: i32, _: *mut u8);
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0);
+                        let l1 = *ptr0.add(0).cast::<*mut u8>();
+                        let l2 = *ptr0.add(4).cast::<usize>();
+                        let len3 = l2;
+                        let bytes3 = _rt::Vec::from_raw_parts(l1.cast(), len3, len3);
+                        _rt::string_lift(bytes3)
+                    }
+                }
+            }
+            impl HttpError2 {
+                #[allow(unused_unsafe, clippy::all)]
+                /// Whether this error is related to a timeout.
+                pub fn is_timeout(&self) -> bool {
+                    unsafe {
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[method]http-error2.is-timeout"]
+                            fn wit_import(_: i32) -> i32;
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32) -> i32 {
+                            unreachable!()
+                        }
+                        let ret = wit_import((self).handle() as i32);
+                        _rt::bool_lift(ret as u8)
+                    }
+                }
+            }
+            impl HttpError2 {
+                #[allow(unused_unsafe, clippy::all)]
+                /// Whether this error was created while building the request.
+                pub fn is_builder(&self) -> bool {
+                    unsafe {
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[method]http-error2.is-builder"]
+                            fn wit_import(_: i32) -> i32;
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32) -> i32 {
+                            unreachable!()
+                        }
+                        let ret = wit_import((self).handle() as i32);
+                        _rt::bool_lift(ret as u8)
+                    }
+                }
+            }
+            impl HttpError2 {
+                #[allow(unused_unsafe, clippy::all)]
+                /// Whether this error is related to a request.
+                pub fn is_request(&self) -> bool {
+                    unsafe {
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[method]http-error2.is-request"]
+                            fn wit_import(_: i32) -> i32;
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32) -> i32 {
+                            unreachable!()
+                        }
+                        let ret = wit_import((self).handle() as i32);
+                        _rt::bool_lift(ret as u8)
+                    }
+                }
+            }
+            impl HttpError2 {
+                #[allow(unused_unsafe, clippy::all)]
+                /// Whether this error is related to the attempt to connect while making the
+                /// request.
+                pub fn is_connect(&self) -> bool {
+                    unsafe {
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[method]http-error2.is-connect"]
+                            fn wit_import(_: i32) -> i32;
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32) -> i32 {
+                            unreachable!()
+                        }
+                        let ret = wit_import((self).handle() as i32);
+                        _rt::bool_lift(ret as u8)
+                    }
+                }
+            }
+            impl HttpRequest2 {
+                #[allow(unused_unsafe, clippy::all)]
+                /// Create a new request from an HTTP method and a URL.
+                pub fn new(method: &str, url: &str) -> Result<HttpRequest2, HttpError2> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 8]);
+                        let mut ret_area = RetArea(
+                            [::core::mem::MaybeUninit::uninit(); 8],
+                        );
+                        let vec0 = method;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let vec1 = url;
+                        let ptr1 = vec1.as_ptr().cast::<u8>();
+                        let len1 = vec1.len();
+                        let ptr2 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[static]http-request2.new"]
+                            fn wit_import(
+                                _: *mut u8,
+                                _: usize,
+                                _: *mut u8,
+                                _: usize,
+                                _: *mut u8,
+                            );
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                            _: usize,
+                            _: *mut u8,
+                        ) {
+                            unreachable!()
+                        }
+                        wit_import(ptr0.cast_mut(), len0, ptr1.cast_mut(), len1, ptr2);
+                        let l3 = i32::from(*ptr2.add(0).cast::<u8>());
+                        match l3 {
+                            0 => {
+                                let e = {
+                                    let l4 = *ptr2.add(4).cast::<i32>();
+                                    HttpRequest2::from_handle(l4 as u32)
+                                };
+                                Ok(e)
+                            }
+                            1 => {
+                                let e = {
+                                    let l5 = *ptr2.add(4).cast::<i32>();
+                                    HttpError2::from_handle(l5 as u32)
+                                };
+                                Err(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
+            impl HttpRequest2 {
+                #[allow(unused_unsafe, clippy::all)]
+                /// Set the HTTP method for this request.
+                pub fn set_method(&self, method: &str) -> Result<(), HttpError2> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 8]);
+                        let mut ret_area = RetArea(
+                            [::core::mem::MaybeUninit::uninit(); 8],
+                        );
+                        let vec0 = method;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[method]http-request2.set-method"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => {
+                                let e = ();
+                                Ok(e)
+                            }
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<i32>();
+                                    HttpError2::from_handle(l3 as u32)
+                                };
+                                Err(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
+            impl HttpRequest2 {
+                #[allow(unused_unsafe, clippy::all)]
+                /// Set the URL for this request.
+                pub fn set_url(&self, url: &str) -> Result<(), HttpError2> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 8]);
+                        let mut ret_area = RetArea(
+                            [::core::mem::MaybeUninit::uninit(); 8],
+                        );
+                        let vec0 = url;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[method]http-request2.set-url"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0, ptr1);
+                        let l2 = i32::from(*ptr1.add(0).cast::<u8>());
+                        match l2 {
+                            0 => {
+                                let e = ();
+                                Ok(e)
+                            }
+                            1 => {
+                                let e = {
+                                    let l3 = *ptr1.add(4).cast::<i32>();
+                                    HttpError2::from_handle(l3 as u32)
+                                };
+                                Err(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
+            impl HttpRequest2 {
+                #[allow(unused_unsafe, clippy::all)]
+                /// Set all the headers for this request at once.
+                ///
+                /// This overrides any headers that have been previously set.
+                pub fn set_headers(
+                    &self,
+                    headers: &[HttpHeaderParam<'_>],
+                ) -> Result<(), HttpError2> {
+                    unsafe {
+                        #[repr(align(4))]
+                        struct RetArea([::core::mem::MaybeUninit<u8>; 8]);
+                        let mut ret_area = RetArea(
+                            [::core::mem::MaybeUninit::uninit(); 8],
+                        );
+                        let vec3 = headers;
+                        let len3 = vec3.len();
+                        let layout3 = _rt::alloc::Layout::from_size_align_unchecked(
+                            vec3.len() * 16,
+                            4,
+                        );
+                        let result3 = if layout3.size() != 0 {
+                            let ptr = _rt::alloc::alloc(layout3).cast::<u8>();
+                            if ptr.is_null() {
+                                _rt::alloc::handle_alloc_error(layout3);
+                            }
+                            ptr
+                        } else {
+                            { ::core::ptr::null_mut() }
+                        };
+                        for (i, e) in vec3.into_iter().enumerate() {
+                            let base = result3.add(i * 16);
+                            {
+                                let HttpHeaderParam { name: name0, value: value0 } = e;
+                                let vec1 = name0;
+                                let ptr1 = vec1.as_ptr().cast::<u8>();
+                                let len1 = vec1.len();
+                                *base.add(4).cast::<usize>() = len1;
+                                *base.add(0).cast::<*mut u8>() = ptr1.cast_mut();
+                                let vec2 = value0;
+                                let ptr2 = vec2.as_ptr().cast::<u8>();
+                                let len2 = vec2.len();
+                                *base.add(12).cast::<usize>() = len2;
+                                *base.add(8).cast::<*mut u8>() = ptr2.cast_mut();
+                            }
+                        }
+                        let ptr4 = ret_area.0.as_mut_ptr().cast::<u8>();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[method]http-request2.set-headers"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, result3, len3, ptr4);
+                        let l5 = i32::from(*ptr4.add(0).cast::<u8>());
+                        if layout3.size() != 0 {
+                            _rt::alloc::dealloc(result3.cast(), layout3);
+                        }
+                        match l5 {
+                            0 => {
+                                let e = ();
+                                Ok(e)
+                            }
+                            1 => {
+                                let e = {
+                                    let l6 = *ptr4.add(4).cast::<i32>();
+                                    HttpError2::from_handle(l6 as u32)
+                                };
+                                Err(e)
+                            }
+                            _ => _rt::invalid_enum_discriminant(),
+                        }
+                    }
+                }
+            }
+            impl HttpRequest2 {
+                #[allow(unused_unsafe, clippy::all)]
+                /// Set the request timeout, in nanoseconds.
+                pub fn set_timeout(&self, timeout: u64) {
+                    unsafe {
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[method]http-request2.set-timeout"]
+                            fn wit_import(_: i32, _: i64);
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: i64) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, _rt::as_i64(&timeout));
+                    }
+                }
+            }
+            impl HttpRequest2 {
+                #[allow(unused_unsafe, clippy::all)]
+                /// Set the body of this request.
+                pub fn set_body(&self, body: &[u8]) {
+                    unsafe {
+                        let vec0 = body;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        extern "C" {
+                            #[link_name = "[method]http-request2.set-body"]
+                            fn wit_import(_: i32, _: *mut u8, _: usize);
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: i32, _: *mut u8, _: usize) {
+                            unreachable!()
+                        }
+                        wit_import((self).handle() as i32, ptr0.cast_mut(), len0);
+                    }
+                }
+            }
+            #[allow(unused_unsafe, clippy::all)]
+            /// Make an HTTP request.
+            ///
+            /// This is similar to `fetch` except it returns an opaque error resource
+            /// instead of an error enum.
+            ///
+            /// # Parameters
+            /// - `request` - A description of the HTTP request to make.
+            ///
+            /// # Traps
+            /// This function will trap if called from outside of a durable transaction.
+            pub fn fetch2(request: HttpRequest2) -> Result<HttpResponse, HttpError2> {
+                unsafe {
+                    #[repr(align(4))]
+                    struct RetArea([::core::mem::MaybeUninit<u8>; 24]);
+                    let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 24]);
+                    let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
+                    #[cfg(target_arch = "wasm32")]
+                    #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                    extern "C" {
+                        #[link_name = "fetch2"]
+                        fn wit_import(_: i32, _: *mut u8);
+                    }
+                    #[cfg(not(target_arch = "wasm32"))]
+                    fn wit_import(_: i32, _: *mut u8) {
+                        unreachable!()
+                    }
+                    wit_import((&request).take_handle() as i32, ptr0);
+                    let l1 = i32::from(*ptr0.add(0).cast::<u8>());
+                    match l1 {
+                        0 => {
+                            let e = {
+                                let l2 = i32::from(*ptr0.add(4).cast::<u16>());
+                                let l3 = *ptr0.add(8).cast::<*mut u8>();
+                                let l4 = *ptr0.add(12).cast::<usize>();
+                                let base11 = l3;
+                                let len11 = l4;
+                                let mut result11 = _rt::Vec::with_capacity(len11);
+                                for i in 0..len11 {
+                                    let base = base11.add(i * 16);
+                                    let e11 = {
+                                        let l5 = *base.add(0).cast::<*mut u8>();
+                                        let l6 = *base.add(4).cast::<usize>();
+                                        let len7 = l6;
+                                        let bytes7 = _rt::Vec::from_raw_parts(
+                                            l5.cast(),
+                                            len7,
+                                            len7,
+                                        );
+                                        let l8 = *base.add(8).cast::<*mut u8>();
+                                        let l9 = *base.add(12).cast::<usize>();
+                                        let len10 = l9;
+                                        HttpHeaderResult {
+                                            name: _rt::string_lift(bytes7),
+                                            value: _rt::Vec::from_raw_parts(l8.cast(), len10, len10),
+                                        }
+                                    };
+                                    result11.push(e11);
+                                }
+                                _rt::cabi_dealloc(base11, len11 * 16, 4);
+                                let l12 = *ptr0.add(16).cast::<*mut u8>();
+                                let l13 = *ptr0.add(20).cast::<usize>();
+                                let len14 = l13;
+                                HttpResponse {
+                                    status: l2 as u16,
+                                    headers: result11,
+                                    body: _rt::Vec::from_raw_parts(l12.cast(), len14, len14),
+                                }
+                            };
+                            Ok(e)
+                        }
+                        1 => {
+                            let e = {
+                                let l15 = *ptr0.add(4).cast::<i32>();
+                                HttpError2::from_handle(l15 as u32)
+                            };
+                            Err(e)
+                        }
+                        _ => _rt::invalid_enum_discriminant(),
+                    }
+                }
+            }
         }
     }
 }
 mod _rt {
     pub use alloc_crate::string::String;
     pub use alloc_crate::vec::Vec;
+    use core::fmt;
+    use core::marker;
+    use core::sync::atomic::{AtomicU32, Ordering::Relaxed};
+    /// A type which represents a component model resource, either imported or
+    /// exported into this component.
+    ///
+    /// This is a low-level wrapper which handles the lifetime of the resource
+    /// (namely this has a destructor). The `T` provided defines the component model
+    /// intrinsics that this wrapper uses.
+    ///
+    /// One of the chief purposes of this type is to provide `Deref` implementations
+    /// to access the underlying data when it is owned.
+    ///
+    /// This type is primarily used in generated code for exported and imported
+    /// resources.
+    #[repr(transparent)]
+    pub struct Resource<T: WasmResource> {
+        handle: AtomicU32,
+        _marker: marker::PhantomData<T>,
+    }
+    /// A trait which all wasm resources implement, namely providing the ability to
+    /// drop a resource.
+    ///
+    /// This generally is implemented by generated code, not user-facing code.
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe trait WasmResource {
+        /// Invokes the `[resource-drop]...` intrinsic.
+        unsafe fn drop(handle: u32);
+    }
+    impl<T: WasmResource> Resource<T> {
+        #[doc(hidden)]
+        pub unsafe fn from_handle(handle: u32) -> Self {
+            debug_assert!(handle != u32::MAX);
+            Self {
+                handle: AtomicU32::new(handle),
+                _marker: marker::PhantomData,
+            }
+        }
+        /// Takes ownership of the handle owned by `resource`.
+        ///
+        /// Note that this ideally would be `into_handle` taking `Resource<T>` by
+        /// ownership. The code generator does not enable that in all situations,
+        /// unfortunately, so this is provided instead.
+        ///
+        /// Also note that `take_handle` is in theory only ever called on values
+        /// owned by a generated function. For example a generated function might
+        /// take `Resource<T>` as an argument but then call `take_handle` on a
+        /// reference to that argument. In that sense the dynamic nature of
+        /// `take_handle` should only be exposed internally to generated code, not
+        /// to user code.
+        #[doc(hidden)]
+        pub fn take_handle(resource: &Resource<T>) -> u32 {
+            resource.handle.swap(u32::MAX, Relaxed)
+        }
+        #[doc(hidden)]
+        pub fn handle(resource: &Resource<T>) -> u32 {
+            resource.handle.load(Relaxed)
+        }
+    }
+    impl<T: WasmResource> fmt::Debug for Resource<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Resource").field("handle", &self.handle).finish()
+        }
+    }
+    impl<T: WasmResource> Drop for Resource<T> {
+        fn drop(&mut self) {
+            unsafe {
+                match self.handle.load(Relaxed) {
+                    u32::MAX => {}
+                    other => T::drop(other),
+                }
+            }
+        }
+    }
     pub use alloc_crate::alloc;
     pub fn as_i64<T: AsI64>(t: T) -> i64 {
         t.as_i64()
@@ -386,23 +997,46 @@ mod _rt {
             core::hint::unreachable_unchecked()
         }
     }
+    pub unsafe fn bool_lift(val: u8) -> bool {
+        if cfg!(debug_assertions) {
+            match val {
+                0 => false,
+                1 => true,
+                _ => panic!("invalid bool discriminant"),
+            }
+        } else {
+            val != 0
+        }
+    }
     extern crate alloc as alloc_crate;
 }
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.30.0:import-http:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 495] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xed\x02\x01A\x02\x01\
-A\x02\x01B\x0f\x01p}\x01r\x02\x04names\x05value\0\x04\0\x0bhttp-header\x03\0\x01\
-\x01p\x02\x01k\0\x01kw\x01r\x05\x06methods\x03urls\x07headers\x03\x04body\x04\x07\
-timeout\x05\x04\0\x0chttp-request\x03\0\x06\x01r\x03\x06status{\x07headers\x03\x04\
-body\0\x04\0\x0dhttp-response\x03\0\x08\x01q\x06\x07timeout\0\0\x0einvalid-metho\
-d\0\0\x0binvalid-url\x01s\0\x13invalid-header-name\0\0\x14invalid-header-value\0\
-\0\x05other\x01s\0\x04\0\x0ahttp-error\x03\0\x0a\x01j\x01\x09\x01\x0b\x01@\x01\x07\
-request\x07\0\x0c\x04\0\x05fetch\x01\x0d\x03\x01\x17durable:core/http@2.3.0\x05\0\
-\x04\x01\x1edurable:core/import-http@2.3.0\x04\0\x0b\x11\x01\0\x0bimport-http\x03\
-\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.215.0\x10wit-\
-bindgen-rust\x060.30.0";
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 1099] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xc9\x07\x01A\x02\x01\
+A\x02\x01B-\x01p}\x01r\x02\x04names\x05value\0\x04\0\x0bhttp-header\x03\0\x01\x01\
+p\x02\x01k\0\x01kw\x01r\x05\x06methods\x03urls\x07headers\x03\x04body\x04\x07tim\
+eout\x05\x04\0\x0chttp-request\x03\0\x06\x01r\x03\x06status{\x07headers\x03\x04b\
+ody\0\x04\0\x0dhttp-response\x03\0\x08\x01q\x06\x07timeout\0\0\x0einvalid-method\
+\0\0\x0binvalid-url\x01s\0\x13invalid-header-name\0\0\x14invalid-header-value\0\0\
+\x05other\x01s\0\x04\0\x0ahttp-error\x03\0\x0a\x04\0\x0bhttp-error2\x03\x01\x04\0\
+\x0dhttp-request2\x03\x01\x01h\x0c\x01@\x01\x04self\x0e\0s\x04\0\x1b[method]http\
+-error2.message\x01\x0f\x01@\x01\x04self\x0e\0\x7f\x04\0\x1e[method]http-error2.\
+is-timeout\x01\x10\x04\0\x1e[method]http-error2.is-builder\x01\x10\x04\0\x1e[met\
+hod]http-error2.is-request\x01\x10\x04\0\x1e[method]http-error2.is-connect\x01\x10\
+\x01i\x0d\x01i\x0c\x01j\x01\x11\x01\x12\x01@\x02\x06methods\x03urls\0\x13\x04\0\x19\
+[static]http-request2.new\x01\x14\x01h\x0d\x01j\0\x01\x12\x01@\x02\x04self\x15\x06\
+methods\0\x16\x04\0\x20[method]http-request2.set-method\x01\x17\x01@\x02\x04self\
+\x15\x03urls\0\x16\x04\0\x1d[method]http-request2.set-url\x01\x18\x01@\x02\x04se\
+lf\x15\x07headers\x03\0\x16\x04\0![method]http-request2.set-headers\x01\x19\x01@\
+\x02\x04self\x15\x07timeoutw\x01\0\x04\0![method]http-request2.set-timeout\x01\x1a\
+\x01@\x02\x04self\x15\x04body\0\x01\0\x04\0\x1e[method]http-request2.set-body\x01\
+\x1b\x01j\x01\x09\x01\x0b\x01@\x01\x07request\x07\0\x1c\x04\0\x05fetch\x01\x1d\x01\
+j\x01\x09\x01\x12\x01@\x01\x07request\x11\0\x1e\x04\0\x06fetch2\x01\x1f\x03\x01\x17\
+durable:core/http@2.4.0\x05\0\x04\x01\x1edurable:core/import-http@2.4.0\x04\0\x0b\
+\x11\x01\0\x0bimport-http\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit\
+-component\x070.215.0\x10wit-bindgen-rust\x060.30.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/crates/durable-runtime/Cargo.toml
+++ b/crates/durable-runtime/Cargo.toml
@@ -49,6 +49,7 @@ tracing = "0.1.40"
 uluru = "3.1.0"
 uuid = { version = "1.10.0", features = ["serde"] }
 wasmtime = { workspace = true }
+url = "2.5.2"
 
 [dependencies.sqlx]
 version = "0.8.0"

--- a/crates/durable-runtime/src/plugin/durable/http.rs
+++ b/crates/durable-runtime/src/plugin/durable/http.rs
@@ -8,13 +8,13 @@ use crate::bindings::durable::core::http::*;
 use crate::{Config, Resourceable, Task};
 
 impl Resourceable for HttpError2 {
-    const NAME: &str = "http-error2";
+    const NAME: &'static str = "http-error2";
 
     type Data = DurableHttpError;
 }
 
 impl Resourceable for HttpRequest2 {
-    const NAME: &str = "http-request2";
+    const NAME: &'static str = "http-request2";
 
     type Data = reqwest::Request;
 }

--- a/crates/durable-runtime/src/plugin/durable/http.rs
+++ b/crates/durable-runtime/src/plugin/durable/http.rs
@@ -1,38 +1,28 @@
 use std::time::Duration;
 
 use http::{HeaderName, HeaderValue, Method};
+use reqwest::Request;
+use wasmtime::component::Resource;
 
 use crate::bindings::durable::core::http::*;
-use crate::Task;
+use crate::{Config, Resourceable, Task};
+
+impl Resourceable for HttpError2 {
+    const NAME: &str = "http-error2";
+
+    type Data = DurableHttpError;
+}
+
+impl Resourceable for HttpRequest2 {
+    const NAME: &str = "http-request2";
+
+    type Data = reqwest::Request;
+}
 
 impl Task {
-    async fn fetch_impl(&mut self, request: HttpRequest) -> Result<HttpResponse, HttpError> {
-        let config = self.state.config();
+    async fn fetch2_impl(&mut self, request: Request) -> Result<HttpResponse, DurableHttpError> {
         let client = self.state.client();
-
-        let method = Method::from_bytes(request.method.as_bytes())?;
-        let timeout = request
-            .timeout
-            .map(Duration::from_nanos)
-            .unwrap_or(config.max_http_timeout)
-            .min(config.max_http_timeout);
-
-        let url = reqwest::Url::parse(&request.url) //
-            .map_err(|e| HttpError::InvalidUrl(e.to_string()))?;
-        let mut builder = client.request(method, url).timeout(timeout);
-
-        if let Some(body) = request.body {
-            builder = builder.body(body);
-        }
-
-        for header in request.headers {
-            let name = HeaderName::from_bytes(header.name.as_bytes())?;
-            let value = HeaderValue::from_bytes(&header.value)?;
-
-            builder = builder.header(name, value);
-        }
-
-        let response = builder.send().await?;
+        let response = client.execute(request).await?;
 
         Ok(HttpResponse {
             status: response.status().as_u16(),
@@ -50,6 +40,169 @@ impl Task {
 }
 
 #[async_trait::async_trait]
+impl HostHttpError2 for Task {
+    async fn message(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<String> {
+        let error = self.resources.get(res)?;
+        Ok(error.to_string())
+    }
+
+    async fn is_timeout(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<bool> {
+        let error = self.resources.get(res)?;
+        Ok(error.is_timeout())
+    }
+
+    async fn is_builder(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<bool> {
+        let error = self.resources.get(res)?;
+        Ok(error.is_builder())
+    }
+
+    async fn is_request(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<bool> {
+        let error = self.resources.get(res)?;
+        Ok(error.is_request())
+    }
+
+    async fn is_connect(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<bool> {
+        let error = self.resources.get(res)?;
+        Ok(error.is_connect())
+    }
+
+    fn drop(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<()> {
+        self.resources.remove(res)?;
+        Ok(())
+    }
+}
+
+impl HttpRequest2 {
+    #[allow(clippy::new_ret_no_self)]
+    fn new(method: String, url: String, config: &Config) -> Result<Request, DurableHttpError> {
+        let method = Method::from_bytes(method.as_bytes())?;
+        let url = url::Url::parse(&url)?;
+
+        let mut request = Request::new(method, url);
+        *request.timeout_mut() = Some(config.max_http_timeout);
+
+        Ok(request)
+    }
+
+    fn set_method(request: &mut Request, method: &str) -> Result<(), DurableHttpError> {
+        let method = Method::from_bytes(method.as_bytes())?;
+        *request.method_mut() = method;
+        Ok(())
+    }
+
+    fn set_url(request: &mut Request, url: &str) -> Result<(), DurableHttpError> {
+        let url = url::Url::parse(url)?;
+        *request.url_mut() = url;
+        Ok(())
+    }
+
+    fn set_headers(request: &mut Request, headers: &[HttpHeader]) -> Result<(), DurableHttpError> {
+        let mut map = http::HeaderMap::with_capacity(headers.len());
+
+        for header in headers {
+            let name = HeaderName::from_bytes(header.name.as_bytes())?;
+            let value = HeaderValue::from_bytes(&header.value)?;
+
+            map.insert(name, value);
+        }
+
+        *request.headers_mut() = map;
+        Ok(())
+    }
+
+    fn set_timeout(request: &mut Request, timeout: Duration, config: &Config) {
+        *request.timeout_mut() = Some(timeout.min(config.max_http_timeout));
+    }
+
+    fn set_body(request: &mut Request, body: Vec<u8>) {
+        *request.body_mut() = Some(reqwest::Body::from(body));
+    }
+}
+
+#[async_trait::async_trait]
+impl HostHttpRequest2 for Task {
+    async fn new(
+        &mut self,
+        method: String,
+        url: String,
+    ) -> wasmtime::Result<Result<Resource<HttpRequest2>, Resource<HttpError2>>> {
+        let config = self.state.config();
+
+        Ok(match HttpRequest2::new(method, url, config) {
+            Ok(request) => Ok(self.resources.insert(request)?),
+            Err(e) => Err(self.resources.insert(e)?),
+        })
+    }
+
+    async fn set_method(
+        &mut self,
+        res: Resource<HttpRequest2>,
+        method: String,
+    ) -> wasmtime::Result<Result<(), Resource<HttpError2>>> {
+        let request = self.resources.get_mut(res)?;
+
+        Ok(match HttpRequest2::set_method(request, &method) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(self.resources.insert(e)?),
+        })
+    }
+
+    async fn set_url(
+        &mut self,
+        res: Resource<HttpRequest2>,
+        url: String,
+    ) -> wasmtime::Result<Result<(), Resource<HttpError2>>> {
+        let request = self.resources.get_mut(res)?;
+
+        Ok(match HttpRequest2::set_url(request, &url) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(self.resources.insert(e)?),
+        })
+    }
+
+    async fn set_headers(
+        &mut self,
+        res: Resource<HttpRequest2>,
+        headers: Vec<HttpHeader>,
+    ) -> wasmtime::Result<Result<(), Resource<HttpError2>>> {
+        let request = self.resources.get_mut(res)?;
+
+        Ok(match HttpRequest2::set_headers(request, &headers) {
+            Ok(()) => Ok(()),
+            Err(e) => Err(self.resources.insert(e)?),
+        })
+    }
+
+    async fn set_timeout(
+        &mut self,
+        res: Resource<HttpRequest2>,
+        timeout: u64,
+    ) -> wasmtime::Result<()> {
+        let request = self.resources.get_mut(res)?;
+        let config = self.state.config();
+
+        HttpRequest2::set_timeout(request, Duration::from_nanos(timeout), config);
+        Ok(())
+    }
+
+    async fn set_body(
+        &mut self,
+        res: Resource<HttpRequest2>,
+        body: Vec<u8>,
+    ) -> wasmtime::Result<()> {
+        let request = self.resources.get_mut(res)?;
+
+        HttpRequest2::set_body(request, body);
+        Ok(())
+    }
+
+    fn drop(&mut self, res: Resource<HttpRequest2>) -> wasmtime::Result<()> {
+        self.resources.remove(res)?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
 impl Host for Task {
     async fn fetch(
         &mut self,
@@ -58,7 +211,43 @@ impl Host for Task {
         self.state
             .assert_in_transaction("durable:http/http.fetch")?;
 
-        Ok(self.fetch_impl(request).await)
+        let config = self.state.config();
+        let result = (|| -> Result<_, DurableHttpError> {
+            let mut req = HttpRequest2::new(request.method, request.url, config)?;
+            HttpRequest2::set_headers(&mut req, &request.headers)?;
+
+            if let Some(timeout) = request.timeout {
+                HttpRequest2::set_timeout(&mut req, Duration::from_nanos(timeout), config);
+            }
+
+            if let Some(body) = request.body {
+                HttpRequest2::set_body(&mut req, body);
+            }
+
+            Ok(req)
+        })();
+
+        let request = match result {
+            Ok(request) => request,
+            Err(e) => return Ok(Err(e.into())),
+        };
+
+        Ok(self.fetch2_impl(request).await.map_err(From::from))
+    }
+
+    async fn fetch2(
+        &mut self,
+        request: Resource<HttpRequest2>,
+    ) -> wasmtime::Result<Result<HttpResponse, Resource<HttpError2>>> {
+        self.state
+            .assert_in_transaction("durable:http/http.fetch2")?;
+
+        let request = self.resources.remove(request)?;
+
+        Ok(match self.fetch2_impl(request).await {
+            Ok(response) => Ok(response),
+            Err(e) => Err(self.resources.insert(e)?),
+        })
     }
 }
 
@@ -87,5 +276,98 @@ impl From<http::header::InvalidHeaderName> for HttpError {
 impl From<http::header::InvalidHeaderValue> for HttpError {
     fn from(_: http::header::InvalidHeaderValue) -> Self {
         Self::InvalidHeaderValue
+    }
+}
+
+pub enum DurableHttpError {
+    InvalidMethod(http::method::InvalidMethod),
+    InvalidUrl(url::ParseError),
+    InvalidHeaderName(http::header::InvalidHeaderName),
+    InvalidHeaderValue(http::header::InvalidHeaderValue),
+    Reqwest(reqwest::Error),
+}
+
+impl DurableHttpError {
+    fn is_timeout(&self) -> bool {
+        match self {
+            Self::Reqwest(e) => e.is_timeout(),
+            _ => false,
+        }
+    }
+
+    fn is_builder(&self) -> bool {
+        match self {
+            Self::Reqwest(e) => e.is_builder(),
+            _ => true,
+        }
+    }
+
+    fn is_request(&self) -> bool {
+        match self {
+            Self::Reqwest(e) => e.is_request(),
+            _ => false,
+        }
+    }
+
+    fn is_connect(&self) -> bool {
+        match self {
+            Self::Reqwest(e) => e.is_connect(),
+            _ => false,
+        }
+    }
+}
+
+impl From<http::method::InvalidMethod> for DurableHttpError {
+    fn from(value: http::method::InvalidMethod) -> Self {
+        Self::InvalidMethod(value)
+    }
+}
+
+impl From<http::header::InvalidHeaderName> for DurableHttpError {
+    fn from(value: http::header::InvalidHeaderName) -> Self {
+        Self::InvalidHeaderName(value)
+    }
+}
+
+impl From<http::header::InvalidHeaderValue> for DurableHttpError {
+    fn from(value: http::header::InvalidHeaderValue) -> Self {
+        Self::InvalidHeaderValue(value)
+    }
+}
+
+impl From<url::ParseError> for DurableHttpError {
+    fn from(value: url::ParseError) -> Self {
+        Self::InvalidUrl(value)
+    }
+}
+
+impl From<reqwest::Error> for DurableHttpError {
+    fn from(value: reqwest::Error) -> Self {
+        Self::Reqwest(value)
+    }
+}
+
+impl From<DurableHttpError> for HttpError {
+    fn from(error: DurableHttpError) -> Self {
+        match error {
+            DurableHttpError::InvalidMethod(_) => HttpError::InvalidMethod,
+            DurableHttpError::InvalidHeaderName(_) => HttpError::InvalidHeaderName,
+            DurableHttpError::InvalidHeaderValue(_) => HttpError::InvalidHeaderValue,
+            DurableHttpError::InvalidUrl(err) => HttpError::InvalidUrl(err.to_string()),
+            DurableHttpError::Reqwest(err) if err.is_timeout() => HttpError::Timeout,
+            DurableHttpError::Reqwest(err) => HttpError::Other(err.to_string()),
+        }
+    }
+}
+
+impl std::fmt::Display for DurableHttpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidMethod(err) => err.fmt(f),
+            Self::InvalidUrl(err) => err.fmt(f),
+            Self::InvalidHeaderName(err) => err.fmt(f),
+            Self::InvalidHeaderValue(err) => err.fmt(f),
+            Self::Reqwest(err) => err.fmt(f),
+        }
     }
 }

--- a/crates/durable-runtime/wit/http.wit
+++ b/crates/durable-runtime/wit/http.wit
@@ -4,6 +4,8 @@ interface http {
         value: list<u8>,
     }
 
+    @deprecated(version = 2.4.0)
+    @since(version = 2.0.0)
     record http-request {
         method: string,
         url: string,
@@ -18,6 +20,8 @@ interface http {
         body: list<u8>
     }
 
+    @deprecated(version = 2.4.0)
+    @since(version = 2.0.0)
     variant http-error {
         timeout,
         invalid-method,
@@ -27,9 +31,69 @@ interface http {
         other(string)
     }
 
-    // Make an HTTP request.
-    //
-    // # Parameters
-    // - `request` - A description of the HTTP request to make.
+    /// Make an HTTP request.
+    ///
+    /// # Parameters
+    /// - `request` - A description of the HTTP request to make.
+    @deprecated(version = 2.4.0)
+    @since(version = 2.0.0)
     fetch: func(request: http-request) -> result<http-response, http-error>;
+
+    @since(version = 2.4.0)
+    resource http-error2 {
+        /// The error message describing what went wrong.
+        message: func() -> string;
+
+        /// Whether this error is related to a timeout.
+        is-timeout: func() -> bool;
+
+        /// Whether this error was created while building the request.
+        is-builder: func() -> bool;
+
+        /// Whether this error is related to a request.
+        is-request: func() -> bool;
+
+        /// Whether this error is related to the attempt to connect while making the
+        /// request.
+        is-connect: func() -> bool;
+    }
+
+    /// A HTTP request.
+    /// 
+    /// In order to actually make the request you will need to call `fetch2`.
+    @since(version = 2.4.0)
+    resource http-request2 {
+        /// Create a new request from an HTTP method and a URL.
+        new: static func(method: string, url: string) -> result<http-request2, http-error2>;
+
+        /// Set the HTTP method for this request.
+        set-method: func(method: string) -> result<_, http-error2>;
+
+        /// Set the URL for this request.
+        set-url: func(url: string) -> result<_, http-error2>;
+
+        /// Set all the headers for this request at once.
+        /// 
+        /// This overrides any headers that have been previously set.
+        set-headers: func(headers: list<http-header>) -> result<_, http-error2>;
+
+        /// Set the request timeout, in nanoseconds.
+        set-timeout: func(timeout: u64);
+
+        /// Set the body of this request.
+        set-body: func(body: list<u8>);
+    }
+
+    /// Make an HTTP request.
+    /// 
+    /// This is similar to `fetch` except it returns an opaque error resource
+    /// instead of an error enum.
+    ///
+    /// # Parameters
+    /// - `request` - A description of the HTTP request to make.
+    /// 
+    /// # Traps
+    /// This function will trap if called from outside of a durable transaction.
+    @since(version = 2.4.0)
+    fetch2: func(request: http-request2) -> result<http-response, http-error2>;
 }

--- a/crates/durable-runtime/wit/imports.wit
+++ b/crates/durable-runtime/wit/imports.wit
@@ -1,4 +1,4 @@
-package durable:core@2.3.0;
+package durable:core@2.4.0;
 
 world imports {
     import core;

--- a/crates/durable-sqlx/src/bindings.rs
+++ b/crates/durable-sqlx/src/bindings.rs
@@ -40,7 +40,7 @@ pub mod durable {
                     unreachable!();
                     #[cfg(target_arch = "wasm32")]
                     {
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[resource-drop]type-info"]
                             fn drop(_: u32);
@@ -213,7 +213,7 @@ pub mod durable {
                     unreachable!();
                     #[cfg(target_arch = "wasm32")]
                     {
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[resource-drop]value"]
                             fn drop(_: u32);
@@ -438,7 +438,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]type-info.name"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -462,7 +462,7 @@ pub mod durable {
                 pub fn compatible(&self, other: &TypeInfo) -> bool {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]type-info.compatible"]
                             fn wit_import(_: i32, _: i32) -> i32;
@@ -485,7 +485,7 @@ pub mod durable {
                 pub fn equal(&self, other: &TypeInfo) -> bool {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]type-info.equal"]
                             fn wit_import(_: i32, _: i32) -> i32;
@@ -508,7 +508,7 @@ pub mod durable {
                 pub fn clone(&self) -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]type-info.clone"]
                             fn wit_import(_: i32) -> i32;
@@ -536,7 +536,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]type-info.serialize"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -596,7 +596,7 @@ pub mod durable {
                         let len0 = vec0.len();
                         let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.deserialize"]
                             fn wit_import(_: *mut u8, _: usize, _: *mut u8);
@@ -656,7 +656,7 @@ pub mod durable {
                         let len0 = vec0.len();
                         let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.with-name"]
                             fn wit_import(_: *mut u8, _: usize, _: *mut u8);
@@ -705,7 +705,7 @@ pub mod durable {
                 pub fn boolean() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.boolean"]
                             fn wit_import() -> i32;
@@ -724,7 +724,7 @@ pub mod durable {
                 pub fn float4() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.float4"]
                             fn wit_import() -> i32;
@@ -743,7 +743,7 @@ pub mod durable {
                 pub fn float8() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.float8"]
                             fn wit_import() -> i32;
@@ -762,7 +762,7 @@ pub mod durable {
                 pub fn int1() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int1"]
                             fn wit_import() -> i32;
@@ -781,7 +781,7 @@ pub mod durable {
                 pub fn int2() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int2"]
                             fn wit_import() -> i32;
@@ -800,7 +800,7 @@ pub mod durable {
                 pub fn int4() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int4"]
                             fn wit_import() -> i32;
@@ -819,7 +819,7 @@ pub mod durable {
                 pub fn int8() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int8"]
                             fn wit_import() -> i32;
@@ -838,7 +838,7 @@ pub mod durable {
                 pub fn text() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.text"]
                             fn wit_import() -> i32;
@@ -857,7 +857,7 @@ pub mod durable {
                 pub fn bytea() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.bytea"]
                             fn wit_import() -> i32;
@@ -876,7 +876,7 @@ pub mod durable {
                 pub fn timestamptz() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.timestamptz"]
                             fn wit_import() -> i32;
@@ -895,7 +895,7 @@ pub mod durable {
                 pub fn timestamp() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.timestamp"]
                             fn wit_import() -> i32;
@@ -914,7 +914,7 @@ pub mod durable {
                 pub fn uuid() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.uuid"]
                             fn wit_import() -> i32;
@@ -933,7 +933,7 @@ pub mod durable {
                 pub fn jsonb() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.jsonb"]
                             fn wit_import() -> i32;
@@ -952,7 +952,7 @@ pub mod durable {
                 pub fn inet() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.inet"]
                             fn wit_import() -> i32;
@@ -971,7 +971,7 @@ pub mod durable {
                 pub fn boolean_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.boolean-array"]
                             fn wit_import() -> i32;
@@ -990,7 +990,7 @@ pub mod durable {
                 pub fn float4_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.float4-array"]
                             fn wit_import() -> i32;
@@ -1009,7 +1009,7 @@ pub mod durable {
                 pub fn float8_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.float8-array"]
                             fn wit_import() -> i32;
@@ -1028,7 +1028,7 @@ pub mod durable {
                 pub fn int1_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int1-array"]
                             fn wit_import() -> i32;
@@ -1047,7 +1047,7 @@ pub mod durable {
                 pub fn int2_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int2-array"]
                             fn wit_import() -> i32;
@@ -1066,7 +1066,7 @@ pub mod durable {
                 pub fn int4_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int4-array"]
                             fn wit_import() -> i32;
@@ -1085,7 +1085,7 @@ pub mod durable {
                 pub fn int8_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int8-array"]
                             fn wit_import() -> i32;
@@ -1104,7 +1104,7 @@ pub mod durable {
                 pub fn text_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.text-array"]
                             fn wit_import() -> i32;
@@ -1123,7 +1123,7 @@ pub mod durable {
                 pub fn bytea_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.bytea-array"]
                             fn wit_import() -> i32;
@@ -1142,7 +1142,7 @@ pub mod durable {
                 pub fn timestamptz_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.timestamptz-array"]
                             fn wit_import() -> i32;
@@ -1161,7 +1161,7 @@ pub mod durable {
                 pub fn timestamp_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.timestamp-array"]
                             fn wit_import() -> i32;
@@ -1180,7 +1180,7 @@ pub mod durable {
                 pub fn uuid_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.uuid-array"]
                             fn wit_import() -> i32;
@@ -1199,7 +1199,7 @@ pub mod durable {
                 pub fn jsonb_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.jsonb-array"]
                             fn wit_import() -> i32;
@@ -1218,7 +1218,7 @@ pub mod durable {
                 pub fn inet_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.inet-array"]
                             fn wit_import() -> i32;
@@ -1240,7 +1240,7 @@ pub mod durable {
                 pub fn is_null(&self) -> bool {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.is-null"]
                             fn wit_import(_: i32) -> i32;
@@ -1260,7 +1260,7 @@ pub mod durable {
                 pub fn type_info(&self) -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.type-info"]
                             fn wit_import(_: i32) -> i32;
@@ -1280,7 +1280,7 @@ pub mod durable {
                 pub fn clone(&self) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.clone"]
                             fn wit_import(_: i32) -> i32;
@@ -1308,7 +1308,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.serialize"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1368,7 +1368,7 @@ pub mod durable {
                         let len0 = vec0.len();
                         let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.deserialize"]
                             fn wit_import(_: *mut u8, _: usize, _: *mut u8);
@@ -1417,7 +1417,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-boolean"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1453,7 +1453,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-float4"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1489,7 +1489,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-float8"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1525,7 +1525,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int1"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1561,7 +1561,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int2"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1597,7 +1597,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int4"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1633,7 +1633,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int8"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1669,7 +1669,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-text"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1712,7 +1712,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-bytea"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1750,7 +1750,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-timestamptz"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1792,7 +1792,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-timestamp"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1832,7 +1832,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-uuid"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1873,7 +1873,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-json"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1916,7 +1916,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-inet"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1978,7 +1978,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-boolean-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2027,7 +2027,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-float4-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2065,7 +2065,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-float8-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2103,7 +2103,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int1-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2141,7 +2141,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int2-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2179,7 +2179,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int4-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2217,7 +2217,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int8-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2255,7 +2255,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-text-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2311,7 +2311,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-bytea-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2362,7 +2362,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-timestamptz-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2400,7 +2400,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-timestamp-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2438,7 +2438,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-uuid-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2476,7 +2476,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-json-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2532,7 +2532,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-inet-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2602,7 +2602,7 @@ pub mod durable {
                 pub fn null(tyinfo: TypeInfo) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.null"]
                             fn wit_import(_: i32) -> i32;
@@ -2621,7 +2621,7 @@ pub mod durable {
                 pub fn boolean(value: bool) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.boolean"]
                             fn wit_import(_: i32) -> i32;
@@ -2645,7 +2645,7 @@ pub mod durable {
                 pub fn float4(value: f32) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.float4"]
                             fn wit_import(_: f32) -> i32;
@@ -2664,7 +2664,7 @@ pub mod durable {
                 pub fn float8(value: f64) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.float8"]
                             fn wit_import(_: f64) -> i32;
@@ -2683,7 +2683,7 @@ pub mod durable {
                 pub fn int1(value: i8) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.int1"]
                             fn wit_import(_: i32) -> i32;
@@ -2702,7 +2702,7 @@ pub mod durable {
                 pub fn int2(value: i16) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.int2"]
                             fn wit_import(_: i32) -> i32;
@@ -2721,7 +2721,7 @@ pub mod durable {
                 pub fn int4(value: i32) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.int4"]
                             fn wit_import(_: i32) -> i32;
@@ -2740,7 +2740,7 @@ pub mod durable {
                 pub fn int8(value: i64) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.int8"]
                             fn wit_import(_: i64) -> i32;
@@ -2762,7 +2762,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.text"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -2784,7 +2784,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.bytea"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -2808,7 +2808,7 @@ pub mod durable {
                             offset: offset0,
                         } = value;
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.timestamptz"]
                             fn wit_import(_: i64, _: i32, _: i32) -> i32;
@@ -2835,7 +2835,7 @@ pub mod durable {
                             subsec_nanos: subsec_nanos0,
                         } = value;
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.timestamp"]
                             fn wit_import(_: i64, _: i32) -> i32;
@@ -2858,7 +2858,7 @@ pub mod durable {
                     unsafe {
                         let Uuid { hi: hi0, lo: lo0 } = value;
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.uuid"]
                             fn wit_import(_: i64, _: i64) -> i32;
@@ -2880,7 +2880,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.jsonb"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -2926,7 +2926,7 @@ pub mod durable {
                         };
                         let ptr4 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.inet"]
                             fn wit_import(_: i32, _: i64, _: i64, _: i32, _: *mut u8);
@@ -2993,7 +2993,7 @@ pub mod durable {
                             }
                         }
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.boolean-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3018,7 +3018,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.float4-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3040,7 +3040,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.float8-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3062,7 +3062,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.int1-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3084,7 +3084,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.int2-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3106,7 +3106,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.int4-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3128,7 +3128,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.int8-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3172,7 +3172,7 @@ pub mod durable {
                             }
                         }
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.text-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3219,7 +3219,7 @@ pub mod durable {
                             }
                         }
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.bytea-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3244,7 +3244,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.timestamptz-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3266,7 +3266,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.timestamp-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3288,7 +3288,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.uuid-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3332,7 +3332,7 @@ pub mod durable {
                             }
                         }
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.jsonb-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3396,7 +3396,7 @@ pub mod durable {
                         }
                         let ptr4 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                         extern "C" {
                             #[link_name = "[static]value.inet-array"]
                             fn wit_import(_: *mut u8, _: usize, _: *mut u8);
@@ -3473,7 +3473,7 @@ pub mod durable {
                     }
                     let Options { limit: limit2, persistent: persistent2 } = options;
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                    #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                     extern "C" {
                         #[link_name = "query"]
                         fn wit_import(
@@ -3521,7 +3521,7 @@ pub mod durable {
                     let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 72]);
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/sql@2.3.0")]
+                    #[link(wasm_import_module = "durable:core/sql@2.4.0")]
                     extern "C" {
                         #[link_name = "fetch"]
                         fn wit_import(_: *mut u8);
@@ -4089,7 +4089,7 @@ atic]value.timestamptz-array\x01\x8c\x01\x01@\x01\x05value\xec\0\0\x0f\x04\0\x1d
 \x01@\x01\x05value\xf2\0\02\x04\0\x18[static]value.inet-array\x01\x8f\x01\x01p\x0f\
 \x01@\x03\x03sqls\x06params\x90\x01\x07options\x18\x01\0\x04\0\x05query\x01\x91\x01\
 \x01j\x01\x16\x01!\x01k\x92\x01\x01@\0\0\x93\x01\x04\0\x05fetch\x01\x94\x01\x03\x01\
-\x16durable:core/sql@2.3.0\x05\0\x04\x01\x1ddurable:core/import-sql@2.3.0\x04\0\x0b\
+\x16durable:core/sql@2.4.0\x05\0\x04\x01\x1ddurable:core/import-sql@2.4.0\x04\0\x0b\
 \x10\x01\0\x0aimport-sql\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-\
 component\x070.215.0\x10wit-bindgen-rust\x060.30.0";
 #[inline(never)]


### PR DESCRIPTION
We will likely want to expose more info about the error in the future. It is impossible to do this if bake all possible variants of the error into a variant type. Making it a resource means that it can evolve in the future.