### PR TITLE
Make the shutdown state of WorkerHandle persistent

### DIFF
--- a/crates/durable-runtime/src/worker.rs
+++ b/crates/durable-runtime/src/worker.rs
@@ -200,8 +200,20 @@ pub struct WorkerHandle {
 }
 
 impl WorkerHandle {
+    /// Tell the [`Worker`] to shut down.
+    ///
+    /// Future calls to [`Worker::run`] will continue to shut down immediately
+    /// until the flag is cleared by calling [`reset`].
+    ///
+    /// [`reset`]: WorkerHandle::reset
     pub fn shutdown(&self) {
         self.shared.shutdown.raise();
+    }
+
+    /// Reset the handle and allow future calls to [`Worker::run`] to process
+    /// workflow tasks.
+    pub fn reset(&self) {
+        self.shared.shutdown.reset();
     }
 }
 
@@ -241,7 +253,6 @@ impl Worker {
 
         tracing::info!("durable worker id is {}", self.worker_id);
 
-        self.shared.shutdown.reset();
         self.load_leader_id().await?;
 
         let worker_id = self.worker_id;


### PR DESCRIPTION
Currently, Worker::run resets the state of its WorkerHandle when it is first called. This results in a problematic race condition between the handle being created and Worker::run being called. If the handle is shutdown during that time then the shutdown signal will be lost. A similar problem happens if Worker::run is run in an error retry loop.

The easy way to avoid this is to make the WorkerHandle state persistent. If shutdown() is called, then it will stay in that state until explicitly cleared by the user of the library. This avoids pretty much all race conditions unless the user of the library needs to use reset, in which case they can synchronize things themselves.