### PR TITLE
Remove dependencies on sqlx macros from xtask

### DIFF
--- a/crates/durable-migrate/Cargo.toml
+++ b/crates/durable-migrate/Cargo.toml
@@ -18,6 +18,7 @@ tracing = { version = "0.1.40", optional = true }
 [dependencies.sqlx]
 version = "0.8.0"
 optional = true
+default-features = false
 features = ["postgres"]
 
 [dev-dependencies]

--- a/crates/durable-runtime/src/task.rs
+++ b/crates/durable-runtime/src/task.rs
@@ -646,7 +646,7 @@ impl TaskState {
         func: F,
     ) -> anyhow::Result<T>
     where
-        F: for<'t> FnOnce(&'t mut Self) -> BoxFuture<anyhow::Result<T>> + Send + 'static,
+        F: for<'t> FnOnce(&'t mut Self) -> BoxFuture<'t, anyhow::Result<T>> + Send + 'static,
         T: Serialize + DeserializeOwned + Send,
     {
         if let Some(data) = self.enter(options).await? {
@@ -682,7 +682,7 @@ impl TaskState {
         func: F,
     ) -> anyhow::Result<T>
     where
-        F: for<'t> FnOnce(&'t mut Transaction) -> BoxFuture<anyhow::Result<T>> + Send + 'static,
+        F: for<'t> FnOnce(&'t mut Transaction) -> BoxFuture<'t, anyhow::Result<T>> + Send + 'static,
         T: Serialize + DeserializeOwned + Send,
     {
         if let Some(txn) = self.transaction_mut() {

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -15,7 +15,6 @@ clap = { version = "4.5.11", features = ["derive"] }
 dotenvy = "0.15.7"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.121"
-sqlx = { version = "0.8.0", features = ["postgres", "runtime-tokio", "tls-rustls"] }
 tokio = { version = "1.39.2", features = ["rt", "macros", "signal", "process"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 xshell = "0.2.6"
@@ -23,3 +22,8 @@ tracing = "0.1.40"
 libc = "0.2.155"
 glob = "0.3.1"
 scopeguard = "1.2.0"
+
+[dependencies.sqlx]
+version = "0.8.0"
+default-features = false
+features = ["json", "postgres", "runtime-tokio", "tls-rustls"]


### PR DESCRIPTION
We don't use these macros there so there is no need to pull it in.