### PR TITLE
Add support for decoding the postgres INET type

### DIFF
--- a/crates/durable-runtime/src/plugin/durable/sql/value.rs
+++ b/crates/durable-runtime/src/plugin/durable/sql/value.rs
@@ -224,6 +224,7 @@ impl<'a> sqlx::Decode<'a, sqlx::Postgres> for ValueResource {
             t if t.type_eq(&oid::TIMESTAMP) => decode(value).map(Value::Timestamp),
             t if t.type_eq(&oid::UUID) => decode(value).map(Value::Uuid),
             t if t.type_eq(&oid::JSON) || t.type_eq(&oid::JSONB) => decode(value).map(Value::Json),
+            t if t.type_eq(&oid::INET) => decode(value).map(Value::Inet),
 
             t if t.type_eq(&oid::BOOL_ARRAY) => decode(value).map(Value::BooleanArray),
             t if t.type_eq(&oid::FLOAT4_ARRAY) => decode(value).map(Value::Float4Array),
@@ -240,6 +241,7 @@ impl<'a> sqlx::Decode<'a, sqlx::Postgres> for ValueResource {
             t if t.type_eq(&oid::JSON_ARRAY) || t.type_eq(&oid::JSONB_ARRAY) => {
                 decode(value).map(Value::JsonArray)
             }
+            t if t.type_eq(&oid::INET_ARRAY) => decode(value).map(Value::InetArray),
 
             t if matches!(t.kind(), PgTypeKind::Enum(_)) => decode(value).map(Value::Text),
 

--- a/crates/durable-test-workflows/src/bin/sqlx-inet.rs
+++ b/crates/durable-test-workflows/src/bin/sqlx-inet.rs
@@ -1,0 +1,27 @@
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use durable::sqlx;
+
+fn main() -> anyhow::Result<()> {
+    let addr = IpAddr::from_str("127.0.0.1")?;
+
+    sqlx::transaction("create the test table", |mut conn| {
+        sqlx::query("CREATE TABLE test(addr inet)").execute(&mut conn)
+    })?;
+
+    sqlx::transaction("insert data", |mut conn| {
+        sqlx::query("INSERT INTO test(addr) VALUES ($1)")
+            .bind(addr)
+            .execute(&mut conn)
+    })?;
+
+    let fetched = sqlx::transaction("fetch data", |mut conn| -> Result<IpAddr, _> {
+        sqlx::query_scalar("SELECT addr FROM test")
+            .fetch_one(&mut conn)
+    })?;
+
+    assert_eq!(addr, fetched);
+
+    Ok(())
+}

--- a/crates/durable-test-workflows/src/bin/sqlx-inet.rs
+++ b/crates/durable-test-workflows/src/bin/sqlx-inet.rs
@@ -17,8 +17,7 @@ fn main() -> anyhow::Result<()> {
     })?;
 
     let fetched = sqlx::transaction("fetch data", |mut conn| -> Result<IpAddr, _> {
-        sqlx::query_scalar("SELECT addr FROM test")
-            .fetch_one(&mut conn)
+        sqlx::query_scalar("SELECT addr FROM test").fetch_one(&mut conn)
     })?;
 
     assert_eq!(addr, fetched);

--- a/crates/durable-test/tests/it/basic.rs
+++ b/crates/durable-test/tests/it/basic.rs
@@ -76,6 +76,23 @@ async fn run_sqlx_enum(pool: sqlx::PgPool) -> anyhow::Result<()> {
 }
 
 #[sqlx::test]
+async fn run_sqlx_inet(pool: sqlx::PgPool) -> anyhow::Result<()> {
+    let _guard = durable_test::spawn_worker(pool.clone()).await?;
+    let client = DurableClient::new(pool)?;
+    let program = crate::load_binary(&client, "sqlx-inet.wasm").await?;
+
+    let task = client
+        .launch("sqlx inet test", &program, &serde_json::json!(null))
+        .await?;
+    crate::tail_logs(&client, &task);
+    let status = task.wait(&client).await?;
+
+    assert!(status.success());
+
+    Ok(())
+}
+
+#[sqlx::test]
 async fn run_sqlx_macros_test(pool: sqlx::PgPool) -> anyhow::Result<()> {
     let _guard = durable_test::spawn_worker(pool.clone()).await?;
     let client = DurableClient::new(pool)?;


### PR DESCRIPTION
The type is already there within the `Value` enum but it never got added to the switch statement in the `sqlx::Decode` impl for `ValueResource`.