### PR TITLE
Add new config option to dump task logs to stdout

### DIFF
--- a/crates/durable-runtime/src/config.rs
+++ b/crates/durable-runtime/src/config.rs
@@ -137,6 +137,12 @@ pub struct Config {
     /// The default limit is 4 concurrent compilation tasks.
     #[serde(default = "default_usize::<4>")]
     pub max_concurrent_compilations: usize,
+
+    /// Print task logs directly to stdout while running.
+    ///
+    /// This is mainly meant as a debugging option for use in tests.
+    #[serde(default)]
+    pub debug_emit_task_logs: bool,
 }
 
 impl Config {

--- a/crates/durable-runtime/src/task.rs
+++ b/crates/durable-runtime/src/task.rs
@@ -514,6 +514,10 @@ impl TaskState {
                 txn.logs
             );
 
+            if self.config().debug_emit_task_logs {
+                print!("{logs}");
+            }
+
             Some(logs)
         };
 

--- a/crates/durable-test/src/lib.rs
+++ b/crates/durable-test/src/lib.rs
@@ -14,7 +14,8 @@ pub async fn spawn_worker(pool: sqlx::PgPool) -> anyhow::Result<WorkerShutdownGu
         .config(
             Config::new()
                 .suspend_margin(Duration::from_secs(1))
-                .suspend_timeout(Duration::from_secs(1)),
+                .suspend_timeout(Duration::from_secs(1))
+                .debug_emit_task_logs(true),
         )
         .wasmtime_config(config)
         .validate_database(false)

--- a/crates/durable-test/tests/it/basic.rs
+++ b/crates/durable-test/tests/it/basic.rs
@@ -12,7 +12,6 @@ async fn check_task_details(pool: sqlx::PgPool) -> anyhow::Result<()> {
     let task = client
         .launch("test task", &program, &serde_json::json!(null))
         .await?;
-    crate::tail_logs(&client, &task);
     let status = task.wait(&client).await?;
 
     assert!(status.success());
@@ -50,7 +49,6 @@ async fn run_sqlx_test(pool: sqlx::PgPool) -> anyhow::Result<()> {
     let task = client
         .launch("test task", &program, &serde_json::json!(null))
         .await?;
-    crate::tail_logs(&client, &task);
     let status = task.wait(&client).await?;
 
     assert!(status.success());
@@ -67,7 +65,6 @@ async fn run_sqlx_enum(pool: sqlx::PgPool) -> anyhow::Result<()> {
     let task = client
         .launch("sqlx enum test", &program, &serde_json::json!(null))
         .await?;
-    crate::tail_logs(&client, &task);
     let status = task.wait(&client).await?;
 
     assert!(status.success());
@@ -84,7 +81,6 @@ async fn run_sqlx_inet(pool: sqlx::PgPool) -> anyhow::Result<()> {
     let task = client
         .launch("sqlx inet test", &program, &serde_json::json!(null))
         .await?;
-    crate::tail_logs(&client, &task);
     let status = task.wait(&client).await?;
 
     assert!(status.success());
@@ -101,7 +97,6 @@ async fn run_sqlx_macros_test(pool: sqlx::PgPool) -> anyhow::Result<()> {
     let task = client
         .launch("wasm macros test", &program, &serde_json::json!(null))
         .await?;
-    crate::tail_logs(&client, &task);
     let status = task.wait(&client).await?;
 
     assert!(status.success());
@@ -118,7 +113,6 @@ async fn run_sqlx_use_json(pool: sqlx::PgPool) -> anyhow::Result<()> {
     let task = client
         .launch("sqlx json types test", &program, &serde_json::json!(null))
         .await?;
-    crate::tail_logs(&client, &task);
     let status = task.wait(&client).await?;
 
     assert!(status.success());
@@ -137,7 +131,6 @@ async fn run_notify_self(pool: sqlx::PgPool) -> anyhow::Result<()> {
     let task = client
         .launch("notify self test", &program, &serde_json::json!(null))
         .await?;
-    crate::tail_logs(&client, &task);
 
     let status = match timeout(Duration::from_secs(30), task.wait(&client)).await {
         Ok(result) => result?,

--- a/crates/durable-test/tests/it/main.rs
+++ b/crates/durable-test/tests/it/main.rs
@@ -8,12 +8,6 @@ use futures::TryStreamExt;
 
 mod basic;
 
-fn test_config() -> Config {
-    Config::default()
-        .suspend_margin(Duration::from_secs(1))
-        .suspend_timeout(Duration::from_secs(1))
-}
-
 async fn load_binary(client: &DurableClient, name: &str) -> anyhow::Result<Program> {
     let program = client
         .program(

--- a/crates/durable-test/tests/it/main.rs
+++ b/crates/durable-test/tests/it/main.rs
@@ -8,35 +8,13 @@ use futures::TryStreamExt;
 
 mod basic;
 
-pub fn test_config() -> Config {
+fn test_config() -> Config {
     Config::default()
         .suspend_margin(Duration::from_secs(1))
         .suspend_timeout(Duration::from_secs(1))
 }
 
-/// Launch a task that tails the logs of the provided task.
-pub fn tail_logs(client: &DurableClient, task: &Task) {
-    let task = task.clone();
-    let client = client.clone();
-
-    tokio::task::spawn(async move {
-        let future = async {
-            let mut stream = std::pin::pin!(task.follow_logs(&client));
-
-            while let Some(logs) = stream.try_next().await? {
-                print!("{logs}");
-            }
-
-            anyhow::Ok(())
-        };
-
-        if let Err(e) = future.await {
-            eprintln!("failed to tail the task logs: {e}")
-        }
-    });
-}
-
-pub async fn load_binary(client: &DurableClient, name: &str) -> anyhow::Result<Program> {
+async fn load_binary(client: &DurableClient, name: &str) -> anyhow::Result<Program> {
     let program = client
         .program(
             ProgramOptions::from_file(crate::test_binary(name))
@@ -47,7 +25,7 @@ pub async fn load_binary(client: &DurableClient, name: &str) -> anyhow::Result<P
     Ok(program)
 }
 
-pub fn test_binary(name: impl AsRef<Path>) -> PathBuf {
+fn test_binary(name: impl AsRef<Path>) -> PathBuf {
     let Some(bindir) = std::env::var_os("DURABLE_TEST_BIN_DIR") else {
         panic!(
             "DURABLE_TEST_BIN_DIR env var is not set. Are you running tests without using `cargo \


### PR DESCRIPTION
This is needed for tests where there isn't a good way to see the logs. By dumping them directly to stdout we avoid having to explicitly tail the logs for each task.