### PR TITLE
Add support for inserting enums into the database

### DIFF
--- a/crates/durable-core/src/bindings.rs
+++ b/crates/durable-core/src/bindings.rs
@@ -13,7 +13,7 @@ pub mod durable {
             pub fn task_id() -> i64 {
                 unsafe {
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/core@2.4.0")]
+                    #[link(wasm_import_module = "durable:core/core@2.5.0")]
                     extern "C" {
                         #[link_name = "task-id"]
                         fn wit_import() -> i64;
@@ -35,7 +35,7 @@ pub mod durable {
                     let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 8]);
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/core@2.4.0")]
+                    #[link(wasm_import_module = "durable:core/core@2.5.0")]
                     extern "C" {
                         #[link_name = "task-name"]
                         fn wit_import(_: *mut u8);
@@ -61,7 +61,7 @@ pub mod durable {
                     let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 8]);
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/core@2.4.0")]
+                    #[link(wasm_import_module = "durable:core/core@2.5.0")]
                     extern "C" {
                         #[link_name = "task-data"]
                         fn wit_import(_: *mut u8);
@@ -98,7 +98,7 @@ pub mod durable {
                     let len0 = vec0.len();
                     let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/core@2.4.0")]
+                    #[link(wasm_import_module = "durable:core/core@2.5.0")]
                     extern "C" {
                         #[link_name = "transaction-enter"]
                         fn wit_import(_: *mut u8, _: usize, _: i32, _: *mut u8);
@@ -148,7 +148,7 @@ pub mod durable {
                     let ptr0 = vec0.as_ptr().cast::<u8>();
                     let len0 = vec0.len();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/core@2.4.0")]
+                    #[link(wasm_import_module = "durable:core/core@2.5.0")]
                     extern "C" {
                         #[link_name = "transaction-exit"]
                         fn wit_import(_: *mut u8, _: usize);
@@ -238,7 +238,7 @@ pub mod durable {
                     let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 32]);
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/notify@2.4.0")]
+                    #[link(wasm_import_module = "durable:core/notify@2.5.0")]
                     extern "C" {
                         #[link_name = "notification-blocking"]
                         fn wit_import(_: *mut u8);
@@ -287,7 +287,7 @@ pub mod durable {
                     let len1 = vec1.len();
                     let ptr2 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/notify@2.4.0")]
+                    #[link(wasm_import_module = "durable:core/notify@2.5.0")]
                     extern "C" {
                         #[link_name = "notify"]
                         fn wit_import(
@@ -505,15 +505,15 @@ pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 665] = *b"\
 A\x07\x01B\x0a\x01@\0\0x\x04\0\x07task-id\x01\0\x01@\0\0s\x04\0\x09task-name\x01\
 \x01\x04\0\x09task-data\x01\x01\x01ks\x01@\x02\x05labels\x05is-db\x7f\0\x02\x04\0\
 \x11transaction-enter\x01\x03\x01@\x01\x04datas\x01\0\x04\0\x10transaction-exit\x01\
-\x04\x03\x01\x17durable:core/core@2.4.0\x05\0\x01B\x05\x01r\x02\x07secondsw\x0bn\
+\x04\x03\x01\x17durable:core/core@2.5.0\x05\0\x01B\x05\x01r\x02\x07secondsw\x0bn\
 anosecondsy\x04\0\x08datetime\x03\0\0\x01@\0\0\x01\x04\0\x03now\x01\x02\x04\0\x0a\
 resolution\x01\x02\x03\x01\x1cwasi:clocks/wall-clock@0.2.0\x05\x01\x02\x03\0\x01\
 \x08datetime\x01B\x0b\x02\x03\x02\x01\x02\x04\0\x08datetime\x03\0\0\x01r\x03\x0a\
 created-at\x01\x05events\x04datas\x04\0\x05event\x03\0\x02\x01q\x03\x0etask-not-\
 found\0\0\x09task-dead\0\0\x05other\x01s\0\x04\0\x0cnotify-error\x03\0\x04\x01@\0\
 \0\x03\x04\0\x15notification-blocking\x01\x06\x01j\0\x01\x05\x01@\x03\x04taskx\x05\
-events\x04datas\0\x07\x04\0\x06notify\x01\x08\x03\x01\x19durable:core/notify@2.4\
-.0\x05\x03\x04\x01\x1edurable:core/import-core@2.4.0\x04\0\x0b\x11\x01\0\x0bimpo\
+events\x04datas\0\x07\x04\0\x06notify\x01\x08\x03\x01\x19durable:core/notify@2.5\
+.0\x05\x03\x04\x01\x1edurable:core/import-core@2.5.0\x04\0\x0b\x11\x01\0\x0bimpo\
 rt-core\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x070.21\
 5.0\x10wit-bindgen-rust\x060.30.0";
 #[inline(never)]

--- a/crates/durable-http/src/bindings.rs
+++ b/crates/durable-http/src/bindings.rs
@@ -153,7 +153,7 @@ pub mod durable {
                     unreachable!();
                     #[cfg(target_arch = "wasm32")]
                     {
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[resource-drop]http-error2"]
                             fn drop(_: u32);
@@ -193,7 +193,7 @@ pub mod durable {
                     unreachable!();
                     #[cfg(target_arch = "wasm32")]
                     {
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[resource-drop]http-request2"]
                             fn drop(_: u32);
@@ -271,7 +271,7 @@ pub mod durable {
                     };
                     let ptr10 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                    #[link(wasm_import_module = "durable:core/http@2.5.0")]
                     extern "C" {
                         #[link_name = "fetch"]
                         fn wit_import(
@@ -424,7 +424,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]http-error2.message"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -448,7 +448,7 @@ pub mod durable {
                 pub fn is_timeout(&self) -> bool {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]http-error2.is-timeout"]
                             fn wit_import(_: i32) -> i32;
@@ -468,7 +468,7 @@ pub mod durable {
                 pub fn is_builder(&self) -> bool {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]http-error2.is-builder"]
                             fn wit_import(_: i32) -> i32;
@@ -488,7 +488,7 @@ pub mod durable {
                 pub fn is_request(&self) -> bool {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]http-error2.is-request"]
                             fn wit_import(_: i32) -> i32;
@@ -509,7 +509,7 @@ pub mod durable {
                 pub fn is_connect(&self) -> bool {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]http-error2.is-connect"]
                             fn wit_import(_: i32) -> i32;
@@ -541,7 +541,7 @@ pub mod durable {
                         let len1 = vec1.len();
                         let ptr2 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]http-request2.new"]
                             fn wit_import(
@@ -599,7 +599,7 @@ pub mod durable {
                         let len0 = vec0.len();
                         let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]http-request2.set-method"]
                             fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
@@ -642,7 +642,7 @@ pub mod durable {
                         let len0 = vec0.len();
                         let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]http-request2.set-url"]
                             fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
@@ -718,7 +718,7 @@ pub mod durable {
                         }
                         let ptr4 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]http-request2.set-headers"]
                             fn wit_import(_: i32, _: *mut u8, _: usize, _: *mut u8);
@@ -755,7 +755,7 @@ pub mod durable {
                 pub fn set_timeout(&self, timeout: u64) {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]http-request2.set-timeout"]
                             fn wit_import(_: i32, _: i64);
@@ -777,7 +777,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/http@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]http-request2.set-body"]
                             fn wit_import(_: i32, _: *mut u8, _: usize);
@@ -808,7 +808,7 @@ pub mod durable {
                     let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 24]);
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/http@2.4.0")]
+                    #[link(wasm_import_module = "durable:core/http@2.5.0")]
                     extern "C" {
                         #[link_name = "fetch2"]
                         fn wit_import(_: i32, _: *mut u8);
@@ -1034,7 +1034,7 @@ lf\x15\x07headers\x03\0\x16\x04\0![method]http-request2.set-headers\x01\x19\x01@
 \x01@\x02\x04self\x15\x04body\0\x01\0\x04\0\x1e[method]http-request2.set-body\x01\
 \x1b\x01j\x01\x09\x01\x0b\x01@\x01\x07request\x07\0\x1c\x04\0\x05fetch\x01\x1d\x01\
 j\x01\x09\x01\x12\x01@\x01\x07request\x11\0\x1e\x04\0\x06fetch2\x01\x1f\x03\x01\x17\
-durable:core/http@2.4.0\x05\0\x04\x01\x1edurable:core/import-http@2.4.0\x04\0\x0b\
+durable:core/http@2.5.0\x05\0\x04\x01\x1edurable:core/import-http@2.5.0\x04\0\x0b\
 \x11\x01\0\x0bimport-http\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit\
 -component\x070.215.0\x10wit-bindgen-rust\x060.30.0";
 #[inline(never)]

--- a/crates/durable-runtime/src/plugin/durable/sql/mod.rs
+++ b/crates/durable-runtime/src/plugin/durable/sql/mod.rs
@@ -779,6 +779,20 @@ impl sql::HostValue for Task {
         self.resources.insert(value).map(Ok)
     }
 
+    async fn enum_value(
+        &mut self,
+        value: String,
+        tyinfo: Resource<sql::TypeInfo>,
+    ) -> wasmtime::Result<Resource<sql::Value>> {
+        let tyinfo = self.resources.get(tyinfo)?.clone();
+        let value = ValueResource {
+            type_info: tyinfo,
+            value: Value::Text(value),
+        };
+
+        self.resources.insert(value)
+    }
+
     async fn boolean_array(&mut self, value: Vec<bool>) -> wasmtime::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
@@ -931,6 +945,20 @@ impl sql::HostValue for Task {
         };
 
         self.resources.insert(value).map(Ok)
+    }
+
+    async fn enum_array(
+        &mut self,
+        value: Vec<String>,
+        tyinfo: Resource<sql::TypeInfo>,
+    ) -> wasmtime::Result<Resource<sql::Value>> {
+        let tyinfo = self.resources.get(tyinfo)?.clone();
+        let value = ValueResource {
+            type_info: tyinfo,
+            value: Value::TextArray(value),
+        };
+
+        self.resources.insert(value)
     }
 
     fn drop(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<()> {

--- a/crates/durable-runtime/wit/imports.wit
+++ b/crates/durable-runtime/wit/imports.wit
@@ -1,4 +1,4 @@
-package durable:core@2.4.0;
+package durable:core@2.5.0;
 
 world imports {
     import core;

--- a/crates/durable-runtime/wit/sql.wit
+++ b/crates/durable-runtime/wit/sql.wit
@@ -212,6 +212,8 @@ interface sql {
         uuid:           static func(value: uuid) -> value;
         jsonb:          static func(value: string) -> value;
         inet:           static func(value: ip-network) -> result<value, string>;
+        @since(version = 2.5.0)
+        enum-value:     static func(value: string, tyinfo: borrow<type-info>) -> value;
 
         boolean-array:  static func(value: list<bool>) -> value;
         float4-array:   static func(value: list<f32>) -> value;
@@ -227,6 +229,8 @@ interface sql {
         uuid-array:     static func(value: list<uuid>) -> value;
         jsonb-array:    static func(value: list<string>) -> value;
         inet-array:     static func(value: list<ip-network>) -> result<value, string>;
+        @since(version = 2.5.0)
+        enum-array:     static func(value: list<string>, tyinfo: borrow<type-info>) -> value;
     }
 
     record column {

--- a/crates/durable-sqlx/src/bindings.rs
+++ b/crates/durable-sqlx/src/bindings.rs
@@ -40,7 +40,7 @@ pub mod durable {
                     unreachable!();
                     #[cfg(target_arch = "wasm32")]
                     {
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[resource-drop]type-info"]
                             fn drop(_: u32);
@@ -213,7 +213,7 @@ pub mod durable {
                     unreachable!();
                     #[cfg(target_arch = "wasm32")]
                     {
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[resource-drop]value"]
                             fn drop(_: u32);
@@ -438,7 +438,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]type-info.name"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -462,7 +462,7 @@ pub mod durable {
                 pub fn compatible(&self, other: &TypeInfo) -> bool {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]type-info.compatible"]
                             fn wit_import(_: i32, _: i32) -> i32;
@@ -485,7 +485,7 @@ pub mod durable {
                 pub fn equal(&self, other: &TypeInfo) -> bool {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]type-info.equal"]
                             fn wit_import(_: i32, _: i32) -> i32;
@@ -508,7 +508,7 @@ pub mod durable {
                 pub fn clone(&self) -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]type-info.clone"]
                             fn wit_import(_: i32) -> i32;
@@ -536,7 +536,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]type-info.serialize"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -596,7 +596,7 @@ pub mod durable {
                         let len0 = vec0.len();
                         let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.deserialize"]
                             fn wit_import(_: *mut u8, _: usize, _: *mut u8);
@@ -656,7 +656,7 @@ pub mod durable {
                         let len0 = vec0.len();
                         let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.with-name"]
                             fn wit_import(_: *mut u8, _: usize, _: *mut u8);
@@ -705,7 +705,7 @@ pub mod durable {
                 pub fn boolean() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.boolean"]
                             fn wit_import() -> i32;
@@ -724,7 +724,7 @@ pub mod durable {
                 pub fn float4() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.float4"]
                             fn wit_import() -> i32;
@@ -743,7 +743,7 @@ pub mod durable {
                 pub fn float8() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.float8"]
                             fn wit_import() -> i32;
@@ -762,7 +762,7 @@ pub mod durable {
                 pub fn int1() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int1"]
                             fn wit_import() -> i32;
@@ -781,7 +781,7 @@ pub mod durable {
                 pub fn int2() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int2"]
                             fn wit_import() -> i32;
@@ -800,7 +800,7 @@ pub mod durable {
                 pub fn int4() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int4"]
                             fn wit_import() -> i32;
@@ -819,7 +819,7 @@ pub mod durable {
                 pub fn int8() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int8"]
                             fn wit_import() -> i32;
@@ -838,7 +838,7 @@ pub mod durable {
                 pub fn text() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.text"]
                             fn wit_import() -> i32;
@@ -857,7 +857,7 @@ pub mod durable {
                 pub fn bytea() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.bytea"]
                             fn wit_import() -> i32;
@@ -876,7 +876,7 @@ pub mod durable {
                 pub fn timestamptz() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.timestamptz"]
                             fn wit_import() -> i32;
@@ -895,7 +895,7 @@ pub mod durable {
                 pub fn timestamp() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.timestamp"]
                             fn wit_import() -> i32;
@@ -914,7 +914,7 @@ pub mod durable {
                 pub fn uuid() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.uuid"]
                             fn wit_import() -> i32;
@@ -933,7 +933,7 @@ pub mod durable {
                 pub fn jsonb() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.jsonb"]
                             fn wit_import() -> i32;
@@ -952,7 +952,7 @@ pub mod durable {
                 pub fn inet() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.inet"]
                             fn wit_import() -> i32;
@@ -971,7 +971,7 @@ pub mod durable {
                 pub fn boolean_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.boolean-array"]
                             fn wit_import() -> i32;
@@ -990,7 +990,7 @@ pub mod durable {
                 pub fn float4_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.float4-array"]
                             fn wit_import() -> i32;
@@ -1009,7 +1009,7 @@ pub mod durable {
                 pub fn float8_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.float8-array"]
                             fn wit_import() -> i32;
@@ -1028,7 +1028,7 @@ pub mod durable {
                 pub fn int1_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int1-array"]
                             fn wit_import() -> i32;
@@ -1047,7 +1047,7 @@ pub mod durable {
                 pub fn int2_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int2-array"]
                             fn wit_import() -> i32;
@@ -1066,7 +1066,7 @@ pub mod durable {
                 pub fn int4_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int4-array"]
                             fn wit_import() -> i32;
@@ -1085,7 +1085,7 @@ pub mod durable {
                 pub fn int8_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.int8-array"]
                             fn wit_import() -> i32;
@@ -1104,7 +1104,7 @@ pub mod durable {
                 pub fn text_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.text-array"]
                             fn wit_import() -> i32;
@@ -1123,7 +1123,7 @@ pub mod durable {
                 pub fn bytea_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.bytea-array"]
                             fn wit_import() -> i32;
@@ -1142,7 +1142,7 @@ pub mod durable {
                 pub fn timestamptz_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.timestamptz-array"]
                             fn wit_import() -> i32;
@@ -1161,7 +1161,7 @@ pub mod durable {
                 pub fn timestamp_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.timestamp-array"]
                             fn wit_import() -> i32;
@@ -1180,7 +1180,7 @@ pub mod durable {
                 pub fn uuid_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.uuid-array"]
                             fn wit_import() -> i32;
@@ -1199,7 +1199,7 @@ pub mod durable {
                 pub fn jsonb_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.jsonb-array"]
                             fn wit_import() -> i32;
@@ -1218,7 +1218,7 @@ pub mod durable {
                 pub fn inet_array() -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]type-info.inet-array"]
                             fn wit_import() -> i32;
@@ -1240,7 +1240,7 @@ pub mod durable {
                 pub fn is_null(&self) -> bool {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.is-null"]
                             fn wit_import(_: i32) -> i32;
@@ -1260,7 +1260,7 @@ pub mod durable {
                 pub fn type_info(&self) -> TypeInfo {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.type-info"]
                             fn wit_import(_: i32) -> i32;
@@ -1280,7 +1280,7 @@ pub mod durable {
                 pub fn clone(&self) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.clone"]
                             fn wit_import(_: i32) -> i32;
@@ -1308,7 +1308,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.serialize"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1368,7 +1368,7 @@ pub mod durable {
                         let len0 = vec0.len();
                         let ptr1 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.deserialize"]
                             fn wit_import(_: *mut u8, _: usize, _: *mut u8);
@@ -1417,7 +1417,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-boolean"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1453,7 +1453,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-float4"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1489,7 +1489,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-float8"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1525,7 +1525,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int1"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1561,7 +1561,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int2"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1597,7 +1597,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int4"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1633,7 +1633,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int8"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1669,7 +1669,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-text"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1712,7 +1712,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-bytea"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1750,7 +1750,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-timestamptz"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1792,7 +1792,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-timestamp"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1832,7 +1832,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-uuid"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1873,7 +1873,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-json"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1916,7 +1916,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-inet"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -1978,7 +1978,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-boolean-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2027,7 +2027,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-float4-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2065,7 +2065,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-float8-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2103,7 +2103,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int1-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2141,7 +2141,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int2-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2179,7 +2179,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int4-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2217,7 +2217,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-int8-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2255,7 +2255,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-text-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2311,7 +2311,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-bytea-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2362,7 +2362,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-timestamptz-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2400,7 +2400,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-timestamp-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2438,7 +2438,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-uuid-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2476,7 +2476,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-json-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2532,7 +2532,7 @@ pub mod durable {
                         );
                         let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[method]value.as-inet-array"]
                             fn wit_import(_: i32, _: *mut u8);
@@ -2602,7 +2602,7 @@ pub mod durable {
                 pub fn null(tyinfo: TypeInfo) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.null"]
                             fn wit_import(_: i32) -> i32;
@@ -2621,7 +2621,7 @@ pub mod durable {
                 pub fn boolean(value: bool) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.boolean"]
                             fn wit_import(_: i32) -> i32;
@@ -2645,7 +2645,7 @@ pub mod durable {
                 pub fn float4(value: f32) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.float4"]
                             fn wit_import(_: f32) -> i32;
@@ -2664,7 +2664,7 @@ pub mod durable {
                 pub fn float8(value: f64) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.float8"]
                             fn wit_import(_: f64) -> i32;
@@ -2683,7 +2683,7 @@ pub mod durable {
                 pub fn int1(value: i8) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.int1"]
                             fn wit_import(_: i32) -> i32;
@@ -2702,7 +2702,7 @@ pub mod durable {
                 pub fn int2(value: i16) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.int2"]
                             fn wit_import(_: i32) -> i32;
@@ -2721,7 +2721,7 @@ pub mod durable {
                 pub fn int4(value: i32) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.int4"]
                             fn wit_import(_: i32) -> i32;
@@ -2740,7 +2740,7 @@ pub mod durable {
                 pub fn int8(value: i64) -> Value {
                     unsafe {
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.int8"]
                             fn wit_import(_: i64) -> i32;
@@ -2762,7 +2762,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.text"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -2784,7 +2784,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.bytea"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -2808,7 +2808,7 @@ pub mod durable {
                             offset: offset0,
                         } = value;
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.timestamptz"]
                             fn wit_import(_: i64, _: i32, _: i32) -> i32;
@@ -2835,7 +2835,7 @@ pub mod durable {
                             subsec_nanos: subsec_nanos0,
                         } = value;
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.timestamp"]
                             fn wit_import(_: i64, _: i32) -> i32;
@@ -2858,7 +2858,7 @@ pub mod durable {
                     unsafe {
                         let Uuid { hi: hi0, lo: lo0 } = value;
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.uuid"]
                             fn wit_import(_: i64, _: i64) -> i32;
@@ -2880,7 +2880,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.jsonb"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -2926,7 +2926,7 @@ pub mod durable {
                         };
                         let ptr4 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.inet"]
                             fn wit_import(_: i32, _: i64, _: i64, _: i32, _: *mut u8);
@@ -2966,6 +2966,32 @@ pub mod durable {
             }
             impl Value {
                 #[allow(unused_unsafe, clippy::all)]
+                pub fn enum_value(value: &str, tyinfo: &TypeInfo) -> Value {
+                    unsafe {
+                        let vec0 = value;
+                        let ptr0 = vec0.as_ptr().cast::<u8>();
+                        let len0 = vec0.len();
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
+                        extern "C" {
+                            #[link_name = "[static]value.enum-value"]
+                            fn wit_import(_: *mut u8, _: usize, _: i32) -> i32;
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: *mut u8, _: usize, _: i32) -> i32 {
+                            unreachable!()
+                        }
+                        let ret = wit_import(
+                            ptr0.cast_mut(),
+                            len0,
+                            (tyinfo).handle() as i32,
+                        );
+                        Value::from_handle(ret as u32)
+                    }
+                }
+            }
+            impl Value {
+                #[allow(unused_unsafe, clippy::all)]
                 pub fn boolean_array(value: &[bool]) -> Value {
                     unsafe {
                         let vec0 = value;
@@ -2993,7 +3019,7 @@ pub mod durable {
                             }
                         }
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.boolean-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3018,7 +3044,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.float4-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3040,7 +3066,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.float8-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3062,7 +3088,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.int1-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3084,7 +3110,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.int2-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3106,7 +3132,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.int4-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3128,7 +3154,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.int8-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3172,7 +3198,7 @@ pub mod durable {
                             }
                         }
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.text-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3219,7 +3245,7 @@ pub mod durable {
                             }
                         }
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.bytea-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3244,7 +3270,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.timestamptz-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3266,7 +3292,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.timestamp-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3288,7 +3314,7 @@ pub mod durable {
                         let ptr0 = vec0.as_ptr().cast::<u8>();
                         let len0 = vec0.len();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.uuid-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3332,7 +3358,7 @@ pub mod durable {
                             }
                         }
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.jsonb-array"]
                             fn wit_import(_: *mut u8, _: usize) -> i32;
@@ -3396,7 +3422,7 @@ pub mod durable {
                         }
                         let ptr4 = ret_area.0.as_mut_ptr().cast::<u8>();
                         #[cfg(target_arch = "wasm32")]
-                        #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                         extern "C" {
                             #[link_name = "[static]value.inet-array"]
                             fn wit_import(_: *mut u8, _: usize, _: *mut u8);
@@ -3437,6 +3463,53 @@ pub mod durable {
                     }
                 }
             }
+            impl Value {
+                #[allow(unused_unsafe, clippy::all)]
+                pub fn enum_array(value: &[&str], tyinfo: &TypeInfo) -> Value {
+                    unsafe {
+                        let vec1 = value;
+                        let len1 = vec1.len();
+                        let layout1 = _rt::alloc::Layout::from_size_align_unchecked(
+                            vec1.len() * 8,
+                            4,
+                        );
+                        let result1 = if layout1.size() != 0 {
+                            let ptr = _rt::alloc::alloc(layout1).cast::<u8>();
+                            if ptr.is_null() {
+                                _rt::alloc::handle_alloc_error(layout1);
+                            }
+                            ptr
+                        } else {
+                            { ::core::ptr::null_mut() }
+                        };
+                        for (i, e) in vec1.into_iter().enumerate() {
+                            let base = result1.add(i * 8);
+                            {
+                                let vec0 = e;
+                                let ptr0 = vec0.as_ptr().cast::<u8>();
+                                let len0 = vec0.len();
+                                *base.add(4).cast::<usize>() = len0;
+                                *base.add(0).cast::<*mut u8>() = ptr0.cast_mut();
+                            }
+                        }
+                        #[cfg(target_arch = "wasm32")]
+                        #[link(wasm_import_module = "durable:core/sql@2.5.0")]
+                        extern "C" {
+                            #[link_name = "[static]value.enum-array"]
+                            fn wit_import(_: *mut u8, _: usize, _: i32) -> i32;
+                        }
+                        #[cfg(not(target_arch = "wasm32"))]
+                        fn wit_import(_: *mut u8, _: usize, _: i32) -> i32 {
+                            unreachable!()
+                        }
+                        let ret = wit_import(result1, len1, (tyinfo).handle() as i32);
+                        if layout1.size() != 0 {
+                            _rt::alloc::dealloc(result1.cast(), layout1);
+                        }
+                        Value::from_handle(ret as u32)
+                    }
+                }
+            }
             #[allow(unused_unsafe, clippy::all)]
             /// Make a query to the database.
             ///
@@ -3473,7 +3546,7 @@ pub mod durable {
                     }
                     let Options { limit: limit2, persistent: persistent2 } = options;
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                    #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                     extern "C" {
                         #[link_name = "query"]
                         fn wit_import(
@@ -3521,7 +3594,7 @@ pub mod durable {
                     let mut ret_area = RetArea([::core::mem::MaybeUninit::uninit(); 72]);
                     let ptr0 = ret_area.0.as_mut_ptr().cast::<u8>();
                     #[cfg(target_arch = "wasm32")]
-                    #[link(wasm_import_module = "durable:core/sql@2.4.0")]
+                    #[link(wasm_import_module = "durable:core/sql@2.5.0")]
                     extern "C" {
                         #[link_name = "fetch"]
                         fn wit_import(_: *mut u8);
@@ -3995,9 +4068,9 @@ mod _rt {
 #[cfg(target_arch = "wasm32")]
 #[link_section = "component-type:wit-bindgen:0.30.0:import-sql:encoded world"]
 #[doc(hidden)]
-pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 4776] = *b"\
-\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\xa7$\x01A\x02\x01A\x02\
-\x01B\xf8\x01\x04\0\x09type-info\x03\x01\x01r\x02\x07secondsx\x0csubsec-nanosy\x04\
+pub static __WIT_BINDGEN_COMPONENT_TYPE: [u8; 4877] = *b"\
+\0asm\x0d\0\x01\0\0\x19\x16wit-component-encoding\x04\0\x07\x8c%\x01A\x02\x01A\x02\
+\x01B\xfc\x01\x04\0\x09type-info\x03\x01\x01r\x02\x07secondsx\x0csubsec-nanosy\x04\
 \0\x09timestamp\x03\0\x01\x01r\x03\x07secondsx\x0csubsec-nanosy\x06offsetz\x04\0\
 \x0btimestamptz\x03\0\x03\x01r\x02\x02hiw\x02low\x04\0\x04uuid\x03\0\x05\x01r\x02\
 \x04addry\x06prefix}\x04\0\x0cipv4-network\x03\0\x07\x01o\x02ww\x01r\x02\x04addr\
@@ -4073,25 +4146,27 @@ tatic]value.text\x01}\x01@\x01\x05value\xc3\0\0\x0f\x04\0\x13[static]value.bytea
 \x01~\x01@\x01\x05value\x04\0\x0f\x04\0\x19[static]value.timestamptz\x01\x7f\x01\
 @\x01\x05value\x02\0\x0f\x04\0\x17[static]value.timestamp\x01\x80\x01\x01@\x01\x05\
 value\x06\0\x0f\x04\0\x12[static]value.uuid\x01\x81\x01\x04\0\x13[static]value.j\
-sonb\x01}\x01@\x01\x05value\x0d\02\x04\0\x12[static]value.inet\x01\x82\x01\x01@\x01\
-\x05value\xce\0\0\x0f\x04\0\x1b[static]value.boolean-array\x01\x83\x01\x01@\x01\x05\
-value\xd1\0\0\x0f\x04\0\x1a[static]value.float4-array\x01\x84\x01\x01@\x01\x05va\
-lue\xd4\0\0\x0f\x04\0\x1a[static]value.float8-array\x01\x85\x01\x01@\x01\x05valu\
-e\xd7\0\0\x0f\x04\0\x18[static]value.int1-array\x01\x86\x01\x01@\x01\x05value\xda\
-\0\0\x0f\x04\0\x18[static]value.int2-array\x01\x87\x01\x01@\x01\x05value\xdd\0\0\
-\x0f\x04\0\x18[static]value.int4-array\x01\x88\x01\x01@\x01\x05value\xe0\0\0\x0f\
-\x04\0\x18[static]value.int8-array\x01\x89\x01\x01@\x01\x05value\xe3\0\0\x0f\x04\
-\0\x18[static]value.text-array\x01\x8a\x01\x01@\x01\x05value\xe6\0\0\x0f\x04\0\x19\
-[static]value.bytea-array\x01\x8b\x01\x01@\x01\x05value\xe9\0\0\x0f\x04\0\x1f[st\
-atic]value.timestamptz-array\x01\x8c\x01\x01@\x01\x05value\xec\0\0\x0f\x04\0\x1d\
-[static]value.timestamp-array\x01\x8d\x01\x01@\x01\x05value\xef\0\0\x0f\x04\0\x18\
-[static]value.uuid-array\x01\x8e\x01\x04\0\x19[static]value.jsonb-array\x01\x8a\x01\
-\x01@\x01\x05value\xf2\0\02\x04\0\x18[static]value.inet-array\x01\x8f\x01\x01p\x0f\
-\x01@\x03\x03sqls\x06params\x90\x01\x07options\x18\x01\0\x04\0\x05query\x01\x91\x01\
-\x01j\x01\x16\x01!\x01k\x92\x01\x01@\0\0\x93\x01\x04\0\x05fetch\x01\x94\x01\x03\x01\
-\x16durable:core/sql@2.4.0\x05\0\x04\x01\x1ddurable:core/import-sql@2.4.0\x04\0\x0b\
-\x10\x01\0\x0aimport-sql\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-\
-component\x070.215.0\x10wit-bindgen-rust\x060.30.0";
+sonb\x01}\x01@\x01\x05value\x0d\02\x04\0\x12[static]value.inet\x01\x82\x01\x01@\x02\
+\x05values\x06tyinfo\"\0\x0f\x04\0\x18[static]value.enum-value\x01\x83\x01\x01@\x01\
+\x05value\xce\0\0\x0f\x04\0\x1b[static]value.boolean-array\x01\x84\x01\x01@\x01\x05\
+value\xd1\0\0\x0f\x04\0\x1a[static]value.float4-array\x01\x85\x01\x01@\x01\x05va\
+lue\xd4\0\0\x0f\x04\0\x1a[static]value.float8-array\x01\x86\x01\x01@\x01\x05valu\
+e\xd7\0\0\x0f\x04\0\x18[static]value.int1-array\x01\x87\x01\x01@\x01\x05value\xda\
+\0\0\x0f\x04\0\x18[static]value.int2-array\x01\x88\x01\x01@\x01\x05value\xdd\0\0\
+\x0f\x04\0\x18[static]value.int4-array\x01\x89\x01\x01@\x01\x05value\xe0\0\0\x0f\
+\x04\0\x18[static]value.int8-array\x01\x8a\x01\x01@\x01\x05value\xe3\0\0\x0f\x04\
+\0\x18[static]value.text-array\x01\x8b\x01\x01@\x01\x05value\xe6\0\0\x0f\x04\0\x19\
+[static]value.bytea-array\x01\x8c\x01\x01@\x01\x05value\xe9\0\0\x0f\x04\0\x1f[st\
+atic]value.timestamptz-array\x01\x8d\x01\x01@\x01\x05value\xec\0\0\x0f\x04\0\x1d\
+[static]value.timestamp-array\x01\x8e\x01\x01@\x01\x05value\xef\0\0\x0f\x04\0\x18\
+[static]value.uuid-array\x01\x8f\x01\x04\0\x19[static]value.jsonb-array\x01\x8b\x01\
+\x01@\x01\x05value\xf2\0\02\x04\0\x18[static]value.inet-array\x01\x90\x01\x01@\x02\
+\x05value\xe3\0\x06tyinfo\"\0\x0f\x04\0\x18[static]value.enum-array\x01\x91\x01\x01\
+p\x0f\x01@\x03\x03sqls\x06params\x92\x01\x07options\x18\x01\0\x04\0\x05query\x01\
+\x93\x01\x01j\x01\x16\x01!\x01k\x94\x01\x01@\0\0\x95\x01\x04\0\x05fetch\x01\x96\x01\
+\x03\x01\x16durable:core/sql@2.5.0\x05\0\x04\x01\x1ddurable:core/import-sql@2.5.\
+0\x04\0\x0b\x10\x01\0\x0aimport-sql\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\
+\x0dwit-component\x070.215.0\x10wit-bindgen-rust\x060.30.0";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/crates/durable-sqlx/src/driver/type_info.rs
+++ b/crates/durable-sqlx/src/driver/type_info.rs
@@ -28,6 +28,10 @@ impl TypeInfo {
         }
     }
 
+    pub(crate) fn as_inner(&self) -> &sql::TypeInfo {
+        &self.tyinfo
+    }
+
     pub(crate) fn into_inner(self) -> sql::TypeInfo {
         self.tyinfo
     }

--- a/crates/durable-sqlx/src/driver/value.rs
+++ b/crates/durable-sqlx/src/driver/value.rs
@@ -18,6 +18,14 @@ impl Value {
     pub fn type_info(&self) -> TypeInfo {
         TypeInfo::new(self.0.type_info())
     }
+
+    pub fn enum_scalar(value: &str, tyinfo: &TypeInfo) -> Self {
+        Self(sql::Value::enum_value(value, tyinfo.as_inner()))
+    }
+
+    pub fn enum_array(values: &[&str], tyinfo: &TypeInfo) -> Self {
+        Self(sql::Value::enum_array(values, tyinfo.as_inner()))
+    }
 }
 
 impl sqlx::Value for Value {

--- a/crates/durable-test-workflows/src/bin/sqlx-enum-insert.rs
+++ b/crates/durable-test-workflows/src/bin/sqlx-enum-insert.rs
@@ -1,0 +1,61 @@
+use std::sync::OnceLock;
+
+use durable::sqlx::driver::{Durable, TypeInfo, Value};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+enum TestDummy {
+    A,
+    B,
+    C,
+    Blargh,
+}
+
+impl sqlx::Encode<'_, Durable> for TestDummy {
+    fn encode_by_ref(
+        &self,
+        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'_>,
+    ) -> Result<sqlx::encode::IsNull, sqlx::error::BoxDynError> {
+        let tyinfo = <Self as sqlx::Type<Durable>>::type_info();
+        let value = match self {
+            Self::A => "a",
+            Self::B => "b",
+            Self::C => "c",
+            Self::Blargh => "blargh",
+        };
+
+        buf.push(Value::enum_scalar(value, &tyinfo));
+        Ok(sqlx::encode::IsNull::No)
+    }
+}
+
+impl sqlx::Type<Durable> for TestDummy {
+    fn type_info() -> <Durable as sqlx::Database>::TypeInfo {
+        static TYINFO_CACHE: OnceLock<TypeInfo> = OnceLock::new();
+
+        // TypeInfo::with_name currently involves a database query within the runtime.
+        // This is expensive, so only do it once and then hand out copies.
+        TYINFO_CACHE
+            .get_or_init(|| {
+                TypeInfo::with_name("test_dummy")
+                    .expect("test_dummy type was not present within the database")
+            })
+            .clone()
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    durable::sqlx::transaction("set up the database schema", |mut conn| {
+        durable::sqlx::query("CREATE TYPE test_dummy AS ENUM('a', 'b', 'c', 'blargh')")
+            .execute(&mut conn)?;
+
+        durable::sqlx::query("CREATE TABLE test(id bigint, value test_dummy)").execute(&mut conn)
+    })?;
+
+    durable::sqlx::transaction("insert into the test table", |mut conn| {
+        durable::sqlx::query("INSERT INTO test(id, value) VALUES(1, $1)")
+            .bind(TestDummy::Blargh)
+            .execute(&mut conn)
+    })?;
+
+    Ok(())
+}

--- a/crates/durable-test/tests/it/main.rs
+++ b/crates/durable-test/tests/it/main.rs
@@ -4,6 +4,7 @@ use anyhow::Context;
 use durable_client::{DurableClient, Program, ProgramOptions};
 
 mod basic;
+mod sqlx;
 
 async fn load_binary(client: &DurableClient, name: &str) -> anyhow::Result<Program> {
     let program = client

--- a/crates/durable-test/tests/it/sqlx.rs
+++ b/crates/durable-test/tests/it/sqlx.rs
@@ -1,0 +1,17 @@
+use durable_client::DurableClient;
+
+#[sqlx::test(fixtures("extra-table"))]
+async fn enum_insert(pool: sqlx::PgPool) -> anyhow::Result<()> {
+    let _guard = durable_test::spawn_worker(pool.clone()).await?;
+    let client = DurableClient::new(pool)?;
+    let program = crate::load_binary(&client, "sqlx-enum-insert.wasm").await?;
+
+    let task = client
+        .launch("enum insert test", &program, &serde_json::json!(null))
+        .await?;
+    let status = task.wait(&client).await?;
+
+    assert!(status.success());
+
+    Ok(())
+}


### PR DESCRIPTION
These were previously getting encoded as text values when being sent to the database. This resulted in the correct wire format, but the TEXT type is not the same as an enum type.