### PR TITLE
Explicitly override the Cache-Control header within the registry

### DIFF
--- a/crates/xtask/src/publish.rs
+++ b/crates/xtask/src/publish.rs
@@ -99,6 +99,16 @@ impl Publish {
 
             println!("Publishing {name} {version}");
             xshell::cmd!(sh, "margo add {path} --registry {repository}").run()?;
+
+            println!("Updating cache control header for {ab}/{cd}/{name}");
+            xshell::cmd!(
+                sh,
+                "
+                gcloud storage objects update gs://systemslab-cargo/{ab}/{cd}/{name}
+                    --cache-control=no-cache
+                "
+            )
+            .run()?;
         }
 
         println!("Generating HTML index");


### PR DESCRIPTION
By default, GCS will return a Cache-Control header with max-age=3600. This is fine for the .crate files in the registry but causes issues for the index files which are updated when a new crate version is published.

By setting the cache policy to no-cache for the index files we can ensure that we don't have to worry about old cached responses.