### PR TITLE
fix: Avoid hanging forever in Task::follow_logs if the task is complete

### DIFF
--- a/crates/durable-client/src/error.rs
+++ b/crates/durable-client/src/error.rs
@@ -30,7 +30,7 @@ mod detail {
         ProgramValidation(wasmparser::BinaryReaderError),
         ProgramIsNotAComponent,
         Database(sqlx::Error),
-        NonexistantWorkflowId(i64),
+        NonexistantTaskId(i64),
     }
 }
 
@@ -52,7 +52,7 @@ impl fmt::Display for DurableError {
                 write!(f, "expected a WASM component but got a WASM module instead")
             }
             ErrorImpl::Database(e) => e.fmt(f),
-            ErrorImpl::NonexistantWorkflowId(id) => write!(f, "no workflow with id {id}"),
+            ErrorImpl::NonexistantTaskId(id) => write!(f, "no task with id {id}"),
         }
     }
 }
@@ -63,7 +63,7 @@ impl std::error::Error for DurableError {
             ErrorImpl::ProgramValidation(e) => Some(e),
             ErrorImpl::ProgramIsNotAComponent => None,
             ErrorImpl::Database(e) => Some(e),
-            ErrorImpl::NonexistantWorkflowId(_) => None,
+            ErrorImpl::NonexistantTaskId(_) => None,
         }
     }
 }


### PR DESCRIPTION
This was waiting for a durable:task-complete notification before exiting. However, if the task was already complete then it would never get an appropriate notification and so it would never exit.

By checking before entering the loop we can ensure we exit if the task has already completed.