### PR TITLE
Automatically set SQLX_OFFLINE when crates are used as dependencies

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,3 +5,6 @@ durable = "run -p durable-cli --bin durable --"
 
 [registries]
 iop-systems = { index = "sparse+http://storage.googleapis.com/systemslab-cargo/" }
+
+[env]
+DURABLE_DEVELOPMENT = "1"

--- a/crates/durable-client/build.rs
+++ b/crates/durable-client/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let development = std::env::var_os("DURABLE_DEVELOPMENT")
+        .map(|var| var == "1" || var == "true")
+        .unwrap_or(false);
+
+    if !development {
+        println!("cargo::rustc-env=SQLX_OFFLINE=true");
+        println!("cargo::rustc-env=SQLX_OFFLINE_DIR=.sqlx");
+    }
+}

--- a/crates/durable-runtime/build.rs
+++ b/crates/durable-runtime/build.rs
@@ -30,9 +30,7 @@ fn _generate(path: &Path, out: &Path, world: &str, opts: &Opts) -> anyhow::Resul
     Ok(())
 }
 
-fn main() -> anyhow::Result<()> {
-    let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
-
+fn generate_bindings(out_dir: &Path) -> anyhow::Result<()> {
     // Method implementations that should be sync.
     //
     // In general sync interfaces are more efficient so it is better to make things
@@ -79,12 +77,37 @@ fn main() -> anyhow::Result<()> {
     let output = out_dir.join("bindings.rs");
     generate("wit", output, "durable:core/imports", &opts)?;
 
+    Ok(())
+}
+
+fn generate_migrations(out_dir: &Path) -> anyhow::Result<()> {
     let migrator = Migrator::from_dir("migrations")?;
     let embed = migrator.embed(&EmbedOptions::default());
     let output = out_dir.join("migrations.rs");
     std::fs::write(&output, &embed)?;
 
     println!("cargo::rustc-check-cfg=cfg(tokio_unstable)");
+
+    Ok(())
+}
+
+fn set_sqlx_offline() {
+    let development = std::env::var_os("DURABLE_DEVELOPMENT")
+        .map(|var| var == "1" || var == "true")
+        .unwrap_or(false);
+
+    if !development {
+        println!("cargo::rustc-env=SQLX_OFFLINE=true");
+        println!("cargo::rustc-env=SQLX_OFFLINE_DIR=.sqlx");
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+
+    set_sqlx_offline();
+    generate_bindings(&out_dir).context("failed to generate wasmtime wit bindings")?;
+    generate_migrations(&out_dir).context("failed to generate database migrations")?;
 
     Ok(())
 }


### PR DESCRIPTION
Users of these libraries may not have a database with the right schema. We don't want to require that so we need to make sure to use the saved .sqlx queries when building as a package.

The way this is done is by setting SQLX_OFFLINE=true and SQLX_OFFLINE_DIR=.sqlx in the build.rs scripts of the relevant packages. This means that the DATABASE_URL environment variable will be ignored and that `cargo sqlx prepare` will not prepare queries for these libraries.

To make it work locally, if DURABLE_DEVELOPMENT=1 then we don't do any overrides. We then set DURABLE_DEVELOPMENT=1 in .cargo/config.toml.