### PR TITLE
Explicitly handle some recoverable sqlx errors instead of failing

### DIFF
--- a/.sqlx/query-8646787e97a2e9c59fa9a1f2f510a48574aa64161b0ccc37be8bb58deaff5783.json
+++ b/.sqlx/query-8646787e97a2e9c59fa9a1f2f510a48574aa64161b0ccc37be8bb58deaff5783.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                                UPDATE durable.task\n                                SET state = 'ready',\n                                    running_on = NULL\n                                WHERE id = $1\n                                  AND running_on = $2\n                                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8646787e97a2e9c59fa9a1f2f510a48574aa64161b0ccc37be8bb58deaff5783"
+}

--- a/.sqlx/query-cf31973a833c40d4d43aa01102e38178092c2ba065b7c7f367ce1cd2a90d2dce.json
+++ b/.sqlx/query-cf31973a833c40d4d43aa01102e38178092c2ba065b7c7f367ce1cd2a90d2dce.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                        UPDATE durable.task\n                          SET state = 'ready',\n                              running_on = NULL\n                        WHERE id = ANY($1::bigint[])\n                          AND running_on = $2\n                        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8Array",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "cf31973a833c40d4d43aa01102e38178092c2ba065b7c7f367ce1cd2a90d2dce"
+}


### PR DESCRIPTION
The whole goal of durable is for its workflows to be reliable. While we can't handle some errors, there are a subset of sqlx errors that are not the fault of the workflow itself and should instead be handled by performing a retry.

This commit handles these and translates them into either retries or runtime-level errors.