### PR TITLE
Add a trace log for when a task exits

### DIFF
--- a/crates/durable-runtime/src/worker.rs
+++ b/crates/durable-runtime/src/worker.rs
@@ -921,6 +921,8 @@ impl Worker {
             }
         }
 
+        tracing::trace!("task exited with status {status:?}");
+
         Ok(())
     }
 


### PR DESCRIPTION
This turned out to be quite useful when debugging, so I've left it in at the trace level.