### PR TITLE
Fix trigger definition for when a task is notified after being suspended

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -763,6 +763,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+dependencies = [
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1058,6 +1068,7 @@ name = "durable-test"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "ctor",
  "dotenvy",
  "durable-client",
  "durable-runtime",
@@ -1065,6 +1076,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
+ "tracing-subscriber",
  "wasmtime",
 ]
 

--- a/crates/durable-runtime/migrations/02_fix_task_update_trigger.down.sql
+++ b/crates/durable-runtime/migrations/02_fix_task_update_trigger.down.sql
@@ -1,0 +1,5 @@
+-- Modify "task_updated" trigger
+CREATE OR REPLACE TRIGGER "task_updated"
+    AFTER UPDATE OF "running_on" ON "durable"."task"
+    FOR EACH ROW WHEN ((new.running_on IS NULL) AND (new.state = ANY (ARRAY['active'::durable.task_state, 'ready'::durable.task_state])))
+    EXECUTE FUNCTION "durable"."notify_task"();

--- a/crates/durable-runtime/migrations/02_fix_task_update_trigger.up.sql
+++ b/crates/durable-runtime/migrations/02_fix_task_update_trigger.up.sql
@@ -1,0 +1,9 @@
+-- Modify "task_updated" trigger
+CREATE OR REPLACE TRIGGER "task_updated"
+    AFTER UPDATE OF "state" ON "durable"."task"
+    FOR EACH ROW WHEN (
+        (new.state = ANY (ARRAY['active'::durable.task_state, 'ready'::durable.task_state]))
+        AND
+        (NOT (old.state = ANY (ARRAY['active'::durable.task_state, 'ready'::durable.task_state])))
+    )
+    EXECUTE FUNCTION "durable"."notify_task"();

--- a/crates/durable-runtime/schema.sql
+++ b/crates/durable-runtime/schema.sql
@@ -233,8 +233,12 @@ CREATE TRIGGER task_inserted
     FOR EACH ROW EXECUTE FUNCTION durable.notify_task();
 
 CREATE TRIGGER task_updated
-    AFTER UPDATE OF running_on ON durable.task
-    FOR EACH ROW WHEN (NEW.running_on IS NULL AND NEW.state IN ('active', 'ready'))
+    AFTER UPDATE OF state ON durable.task
+    FOR EACH ROW WHEN (
+        NEW.state IN ('active', 'ready')
+        AND
+        NOT OLD.state IN ('active', 'ready')
+    )
     EXECUTE FUNCTION durable.notify_task();
 
 CREATE TRIGGER task_suspended

--- a/crates/durable-test/Cargo.toml
+++ b/crates/durable-test/Cargo.toml
@@ -16,3 +16,5 @@ sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls"] }
 tokio = { version = "1.0", features = ["full", "macros"] }
 wasmtime = { workspace = true }
 futures = "0.3.30"
+ctor = "0.2.8"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }

--- a/crates/durable-test/tests/it/notify.rs
+++ b/crates/durable-test/tests/it/notify.rs
@@ -1,6 +1,9 @@
 use std::time::Duration;
 
+use anyhow::Context;
 use durable_client::DurableClient;
+use durable_runtime::Config;
+use sqlx::postgres::PgListener;
 
 #[sqlx::test]
 async fn notify_self(pool: sqlx::PgPool) -> anyhow::Result<()> {
@@ -41,6 +44,62 @@ async fn notify_in_advance(pool: sqlx::PgPool) -> anyhow::Result<()> {
         Ok(result) => result?,
         Err(_) => anyhow::bail!("task failed to complete in under 30s"),
     };
+    assert!(status.success());
+
+    Ok(())
+}
+
+#[sqlx::test]
+async fn notify_after_suspend(pool: sqlx::PgPool) -> anyhow::Result<()> {
+    let client = DurableClient::new(pool.clone())?;
+    let program = crate::load_binary(&client, "notify-wait.wasm").await?;
+    let task = client
+        .launch("notify self test", &program, &serde_json::json!(null))
+        .await?;
+
+    let mut listener = PgListener::connect_with(&pool).await?;
+    listener.listen("durable:task-suspend").await?;
+
+    let _guard = durable_test::spawn_worker_with(
+        pool.clone(),
+        Config::new()
+            .suspend_margin(Duration::ZERO)
+            .suspend_timeout(Duration::ZERO),
+    )
+    .await?;
+
+    let future = async {
+        loop {
+            let _ = listener.try_recv().await?;
+
+            let suspended = sqlx::query_scalar!(
+                r#"
+                SELECT state = 'suspended' as "state!"
+                FROM durable.task
+                WHERE id = $1
+                "#,
+                task.id()
+            )
+            .fetch_one(&pool)
+            .await?;
+
+            if suspended {
+                break;
+            }
+        }
+
+        anyhow::Ok(())
+    };
+
+    tokio::time::timeout(Duration::from_secs(30), future)
+        .await
+        .context("task failed to suspend itself within 30s")??;
+
+    task.notify("notification", &(), &client).await?;
+
+    let status = tokio::time::timeout(Duration::from_secs(30), task.wait(&client))
+        .await
+        .context("task failed to complete in under 30s")??;
     assert!(status.success());
 
     Ok(())

--- a/schema-diff.sh
+++ b/schema-diff.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/bash
+
+set -eux
+
+rm -rf target/schema
+rm -f target/migration.up.sql
+rm -f target/migration.down.sql
+
+mkdir -p target/schema
+
+cp crates/durable-runtime/migrations/*.up.sql target/schema/
+atlas migrate hash --dir file://target/schema
+
+atlas schema diff                                               \
+    --from file://target/schema                                 \
+    --to   file://crates/durable-runtime/schema.sql             \
+    --dev-url 'docker://postgres/15/test'                       \
+    > target/migration.up.sql
+
+atlas schema diff                                               \
+    --to   file://target/schema                                 \
+    --from file://crates/durable-runtime/schema.sql             \
+    --dev-url 'docker://postgres/15/test'                       \
+    > target/migration.down.sql


### PR DESCRIPTION
The trigger was only firing when running_on is changed to NULL. Unfortunately, the trigger reviving the suspended task actually sets running_on to the id of a random worker. So no notifications are sent and the task never starts executing.

This PR changes the trigger to fire whenever the task state changes from a non-active state to an active one.