### PR TITLE
Limit the subquery returning random workers to return 1 row

### DIFF
--- a/crates/durable-runtime/migrations/03_limit_notify_subquery.down.sql
+++ b/crates/durable-runtime/migrations/03_limit_notify_subquery.down.sql
@@ -1,0 +1,27 @@
+-- Modify "notify_notification" function
+CREATE OR REPLACE FUNCTION "durable"."notify_notification" () RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+        PERFORM pg_notify(
+            'durable:notification',
+            jsonb_build_object(
+                'task_id', NEW.task_id,
+                'event', NEW.event
+            )::text
+        );
+
+        -- Wake up the related task when a notification occurs.
+        UPDATE durable.task
+        SET state = 'ready',
+            wakeup_at = NULL,
+            running_on = (
+                SELECT id
+                 FROM durable.worker
+                ORDER BY random()
+                FOR SHARE SKIP LOCKED
+            )
+        WHERE id = NEW.task_id
+          AND state = 'suspended';
+
+        RETURN NULL;
+    END;
+$$;

--- a/crates/durable-runtime/migrations/03_limit_notify_subquery.up.sql
+++ b/crates/durable-runtime/migrations/03_limit_notify_subquery.up.sql
@@ -1,0 +1,28 @@
+-- Modify "notify_notification" function
+CREATE OR REPLACE FUNCTION "durable"."notify_notification" () RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+        PERFORM pg_notify(
+            'durable:notification',
+            jsonb_build_object(
+                'task_id', NEW.task_id,
+                'event', NEW.event
+            )::text
+        );
+
+        -- Wake up the related task when a notification occurs.
+        UPDATE durable.task
+        SET state = 'ready',
+            wakeup_at = NULL,
+            running_on = (
+                SELECT id
+                 FROM durable.worker
+                ORDER BY random()
+                FOR SHARE SKIP LOCKED
+                LIMIT 1
+            )
+        WHERE id = NEW.task_id
+          AND state = 'suspended';
+
+        RETURN NULL;
+    END;
+$$;

--- a/crates/durable-runtime/schema.sql
+++ b/crates/durable-runtime/schema.sql
@@ -189,6 +189,7 @@ CREATE FUNCTION durable.notify_notification() RETURNS trigger as $$
                  FROM durable.worker
                 ORDER BY random()
                 FOR SHARE SKIP LOCKED
+                LIMIT 1
             )
         WHERE id = NEW.task_id
           AND state = 'suspended';

--- a/crates/durable-test/tests/it/notify.rs
+++ b/crates/durable-test/tests/it/notify.rs
@@ -104,3 +104,67 @@ async fn notify_after_suspend(pool: sqlx::PgPool) -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[sqlx::test]
+async fn notify_multiple_workers(pool: sqlx::PgPool) -> anyhow::Result<()> {
+    let client = DurableClient::new(pool.clone())?;
+    let program = crate::load_binary(&client, "notify-wait.wasm").await?;
+    let task = client
+        .launch("notify self test", &program, &serde_json::json!(null))
+        .await?;
+
+    let mut listener = PgListener::connect_with(&pool).await?;
+    listener.listen("durable:task-suspend").await?;
+
+    let _guard1 = durable_test::spawn_worker_with(
+        pool.clone(),
+        Config::new()
+            .suspend_margin(Duration::ZERO)
+            .suspend_timeout(Duration::ZERO),
+    )
+    .await?;
+
+    let _guard2 = durable_test::spawn_worker_with(
+        pool.clone(),
+        Config::new()
+            .suspend_margin(Duration::ZERO)
+            .suspend_timeout(Duration::ZERO),
+    )
+    .await?;
+
+    let future = async {
+        loop {
+            let _ = listener.try_recv().await?;
+
+            let suspended = sqlx::query_scalar!(
+                r#"
+                SELECT state = 'suspended' as "state!"
+                FROM durable.task
+                WHERE id = $1
+                "#,
+                task.id()
+            )
+            .fetch_one(&pool)
+            .await?;
+
+            if suspended {
+                break;
+            }
+        }
+
+        anyhow::Ok(())
+    };
+
+    tokio::time::timeout(Duration::from_secs(30), future)
+        .await
+        .context("task failed to suspend itself within 30s")??;
+
+    task.notify("notification", &(), &client).await?;
+
+    let status = tokio::time::timeout(Duration::from_secs(30), task.wait(&client))
+        .await
+        .context("task failed to complete in under 30s")??;
+    assert!(status.success());
+
+    Ok(())
+}


### PR DESCRIPTION
This would result in an error if there are multiple workers and a notification is sent.