### PR TITLE
Add default timestamps to events and logs

### DIFF
--- a/crates/durable-runtime/migrations/04_column_timestamp.down.sql
+++ b/crates/durable-runtime/migrations/04_column_timestamp.down.sql
@@ -1,0 +1,4 @@
+-- Modify "event" table
+ALTER TABLE "durable"."event" DROP COLUMN "created_at";
+-- Modify "log" table
+ALTER TABLE "durable"."log" DROP COLUMN "created_at";

--- a/crates/durable-runtime/migrations/04_column_timestamp.up.sql
+++ b/crates/durable-runtime/migrations/04_column_timestamp.up.sql
@@ -1,0 +1,4 @@
+-- Modify "event" table
+ALTER TABLE "durable"."event" ADD COLUMN "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP;
+-- Modify "log" table
+ALTER TABLE "durable"."log" ADD COLUMN "created_at" timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/crates/durable-runtime/schema.sql
+++ b/crates/durable-runtime/schema.sql
@@ -96,6 +96,7 @@ CREATE INDEX task_suspended ON durable.task(wakeup_at ASC NULLS LAST)
 CREATE TABLE durable.event(
     task_id         bigint      NOT NULL,
     index           int         NOT NULL,
+    created_at      timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     -- A user-visible text label. Used for debugging and for ensuring that
     -- the events requested are consistent.
@@ -127,6 +128,7 @@ CREATE TABLE durable.log(
     task_id         bigint      NOT NULL,
     index           int         NOT NULL,
     message         text        NOT NULL,
+    created_at      timestamptz NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
     PRIMARY KEY(task_id, index),
 


### PR DESCRIPTION
These are incredibly useful for debugging purposes, even if they aren't specifically needed by durable itself.