### PR TITLE
Add leader task to delete old workflows

### DIFF
--- a/.sqlx/query-dadbe61077d006ce342f60e7c98d04204dee2e7fc10b5d4a7a2fd0ae0f89dd0f.json
+++ b/.sqlx/query-dadbe61077d006ce342f60e7c98d04204dee2e7fc10b5d4a7a2fd0ae0f89dd0f.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    DELETE FROM durable.task\n                    WHERE task.ctid = ANY(ARRAY(\n                        SELECT ctid\n                        FROM durable.task\n                        WHERE completed_at < NOW() - $1::interval\n                        LIMIT $2\n                        FOR UPDATE\n                    ))\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Interval",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "dadbe61077d006ce342f60e7c98d04204dee2e7fc10b5d4a7a2fd0ae0f89dd0f"
+}


### PR DESCRIPTION
As old tasks and event entries pile up they end up slowing down the execution of new tasks. They also end up using up database disk space.

This commit adds a task that automatically deletes old completed tasks once a configurable amount of time has passed.