### PR TITLE
Explicitly reconnect PgListener before returning Event::Lagged

### DIFF
--- a/crates/durable-runtime/src/config.rs
+++ b/crates/durable-runtime/src/config.rs
@@ -237,7 +237,7 @@ mod duration_seconds {
 
         struct Visitor;
 
-        impl<'de> serde::de::Visitor<'de> for Visitor {
+        impl serde::de::Visitor<'_> for Visitor {
             type Value = Duration;
 
             fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/crates/durable-runtime/src/flag.rs
+++ b/crates/durable-runtime/src/flag.rs
@@ -85,7 +85,7 @@ impl<'a> ShutdownGuard<'a> {
     }
 }
 
-impl<'a> Drop for ShutdownGuard<'a> {
+impl Drop for ShutdownGuard<'_> {
     fn drop(&mut self) {
         if !self.0.is_raised() {
             tracing::warn!(

--- a/crates/durable-runtime/src/util/mailbox.rs
+++ b/crates/durable-runtime/src/util/mailbox.rs
@@ -74,7 +74,7 @@ impl<'a, T: Copy> MailboxStream<'a, T> {
     }
 }
 
-impl<'a, T: Copy> Stream for MailboxStream<'a, T> {
+impl<T: Copy> Stream for MailboxStream<'_, T> {
     type Item = T;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {

--- a/crates/durable-runtime/src/worker.rs
+++ b/crates/durable-runtime/src/worker.rs
@@ -1,11 +1,8 @@
-use std::collections::VecDeque;
 use std::panic::AssertUnwindSafe;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Context;
-use async_stream::try_stream;
 use async_trait::async_trait;
 use cache_compute::Cached;
 use cfg_if::cfg_if;


### PR DESCRIPTION
By default, PgListener reconnects on the next call to try_recv. However, reading the database state in order to recover from missing a message happens before that call to try_recv. This means that there is a race condition. If a notification is emitted after the recovery but before the connection is established then it will be lost.

In practice, this manifests as the worker getting stuck in some rare conditions where some tasks are marked as ready during the race period and then the worker remains stuck until another task becomes ready, potentially forever. It is much easier to trigger this when the pool is under high load, since queueing within sqlx::PgPool means that there is a much larger period between recovering and the new listener connection being ready.

This commit fixes the issue by running a dummy query before returning Event::Lagged, which forces PgListener to reconnect before we perform recovery.