### PR TITLE
Add some basic metrics to the runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,6 +1006,7 @@ dependencies = [
  "humantime",
  "ipnetwork",
  "log",
+ "metrics",
  "parking_lot",
  "pin-project",
  "rand",
@@ -2052,6 +2053,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae428771d17306715c5091d446327d1cfdedc82185c65ba8423ab404e45bf10"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,6 +2379,12 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "postcard"

--- a/crates/durable-runtime/Cargo.toml
+++ b/crates/durable-runtime/Cargo.toml
@@ -50,6 +50,7 @@ uluru = "3.1.0"
 uuid = { version = "1.10.0", features = ["serde"] }
 wasmtime = { workspace = true }
 url = "2.5.2"
+metrics = "0.24.0"
 
 [dependencies.sqlx]
 version = "0.8.0"

--- a/crates/durable-runtime/src/util/metrics.rs
+++ b/crates/durable-runtime/src/util/metrics.rs
@@ -1,0 +1,20 @@
+use metrics::Gauge;
+
+/// A span that increments a gauge upon being entered and decrements it on exit.
+pub(crate) struct MetricSpan {
+    gauge: Gauge,
+}
+
+impl MetricSpan {
+    pub fn enter(gauge: Gauge) -> Self {
+        gauge.increment(1);
+
+        Self { gauge }
+    }
+}
+
+impl Drop for MetricSpan {
+    fn drop(&mut self) {
+        self.gauge.decrement(1);
+    }
+}

--- a/crates/durable-runtime/src/util/mod.rs
+++ b/crates/durable-runtime/src/util/mod.rs
@@ -1,9 +1,11 @@
 mod asyncfn;
 mod interval;
 mod mailbox;
+mod metrics;
 mod serde;
 
 pub use self::asyncfn::AsyncFnOnce;
 pub(crate) use self::interval::IntoPgInterval;
 pub(crate) use self::mailbox::Mailbox;
+pub(crate) use self::metrics::MetricSpan;
 pub(crate) use self::serde::EmptyMapDeserializer;


### PR DESCRIPTION
It is useful to export some metrics when monitoring things. This change adds a few metrics, and paves the way for more in the future.