### PR TITLE
Add fallback handler for stuck notifications

### DIFF
--- a/.sqlx/query-7a204104ee904fe7004337a7e7f8c2210d9ff9eb79c1224f2ce1d6a33fcbf247.json
+++ b/.sqlx/query-7a204104ee904fe7004337a7e7f8c2210d9ff9eb79c1224f2ce1d6a33fcbf247.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                UPDATE durable.task\n                  SET state = 'ready'\n                WHERE state = 'suspended'\n                  AND EXISTS((\n                    SELECT task_id\n                     FROM durable.notification\n                    WHERE task_id = task.id\n                      AND created_at < NOW() - '10 minutes'::interval\n                  ))\n                ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": []
+  },
+  "hash": "7a204104ee904fe7004337a7e7f8c2210d9ff9eb79c1224f2ce1d6a33fcbf247"
+}


### PR DESCRIPTION
It is possible for a task to be stuck in the suspended state despite it having a notification. This commit adds a final fallback that periodically resumes any suspended tasks that have notifications.