### PR TITLE
Speed up task resumption by caching a list of events

### DIFF
--- a/.sqlx/query-c7e93c8b478730b7079610807c7dfcd0d83855bfb315e2e5515dbc0d6a1b017f.json
+++ b/.sqlx/query-c7e93c8b478730b7079610807c7dfcd0d83855bfb315e2e5515dbc0d6a1b017f.json
@@ -1,0 +1,34 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT\n                index,\n                label,\n                value as \"value!: Json<Box<RawValue>>\"\n             FROM durable.event\n            WHERE task_id = $1\n            ORDER BY index ASC\n            LIMIT 1000\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 1,
+        "name": "label",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "value!: Json<Box<RawValue>>",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "c7e93c8b478730b7079610807c7dfcd0d83855bfb315e2e5515dbc0d6a1b017f"
+}

--- a/crates/durable-runtime/src/plugin/wasi/clocks.rs
+++ b/crates/durable-runtime/src/plugin/wasi/clocks.rs
@@ -37,7 +37,6 @@ impl wasi::clocks::wall_clock::Host for Task {
                 Ok(Datetime::from(duration))
             })
             .await
-            .map(From::from)
     }
 
     fn resolution(&mut self) -> wasmtime::Result<Datetime> {


### PR DESCRIPTION
When a task is resumed it needs to replay up to the point where it left off. This involves quite a few database queries and can be rather slow. By reading the whole list of events at the start we can avoid hitting the database during replay, which makes things much faster.