### PR TITLE
Add sqlx::Encode<Durable> implementation for Option<T>

### DIFF
--- a/crates/durable-sqlx/src/driver/types/mod.rs
+++ b/crates/durable-sqlx/src/driver/types/mod.rs
@@ -92,6 +92,7 @@ mod int;
 mod ipnetwork;
 #[cfg(feature = "json")]
 mod json;
+mod option;
 mod text;
 #[cfg(feature = "uuid")]
 mod uuid;

--- a/crates/durable-sqlx/src/driver/types/option.rs
+++ b/crates/durable-sqlx/src/driver/types/option.rs
@@ -1,0 +1,19 @@
+use sqlx::encode::IsNull;
+use sqlx::error::BoxDynError;
+
+use crate::Durable;
+
+impl<'r, T> sqlx::Encode<'r, Durable> for Option<T>
+where
+    T: sqlx::Encode<'r, Durable>,
+{
+    fn encode_by_ref(
+        &self,
+        buf: &mut <Durable as sqlx::Database>::ArgumentBuffer<'r>,
+    ) -> Result<IsNull, BoxDynError> {
+        match self {
+            Some(value) => value.encode_by_ref(buf),
+            None => Ok(IsNull::Yes),
+        }
+    }
+}


### PR DESCRIPTION
sqlx has generic Decode and Type implementations for Option<T> but not Encode.

cc @mihirn this should fix your issue.