### PR TITLE
Update durable-sqlx to address some breaking changes in 0.8.3 -> 0.8.4

### DIFF
--- a/crates/durable-sqlx/Cargo.toml
+++ b/crates/durable-sqlx/Cargo.toml
@@ -28,8 +28,8 @@ ipnetwork = { version = "0.20.0", features = ["serde"], optional = true }
 log = "0.4.22"
 serde = "1.0.204"
 serde_json = { version = "1.0", features = ["raw_value"] }
-sqlx = { version = "0.8.0", default-features = false }
-sqlx-core = { version = "0.8.0", default-features = false }
+sqlx = { version = "0.8.5", default-features = false }
+sqlx-core = { version = "0.8.5", default-features = false }
 url = "2.5.2"
 wit-bindgen-rt = { workspace = true }
 thiserror = "2.0.0"

--- a/crates/durable-sqlx/src/driver/connection.rs
+++ b/crates/durable-sqlx/src/driver/connection.rs
@@ -104,7 +104,7 @@ impl sqlx::Connection for Connection {
     fn begin(
         &mut self,
     ) -> BoxFuture<'_, Result<sqlx::Transaction<'_, Self::Database>, sqlx::Error>> {
-        sqlx::Transaction::begin(self)
+        sqlx::Transaction::begin(self, None)
     }
 
     fn shrink_buffers(&mut self) {}


### PR DESCRIPTION
These are technically not breaking changes since they are related to undocumented methods, but we need to implement them anyway as it is necessary to implement the traits.