### PR TITLE
Avoid linking to durable_ctor_wrapper on non-wasm platforms

### DIFF
--- a/crates/durable-core/src/start.rs
+++ b/crates/durable-core/src/start.rs
@@ -14,11 +14,11 @@ extern "C" {
 
 #[no_mangle]
 extern "C" fn durable_ctor() {
-    if cfg!(target_arch = "wasm32") {
-        std::panic::set_hook(Box::new(durable_panic_hook))
-    }
+    #[cfg(target_arch = "wasm")]
+    std::panic::set_hook(Box::new(durable_panic_hook))
 }
 
+#[cfg(target_arch = "wasm")]
 fn durable_panic_hook(info: &PanicInfo) {
     #[used]
     static __UNUSED_LINK_HACK: unsafe extern "C" fn() = durable_ctor_wrapper;

--- a/crates/durable-core/src/start.rs
+++ b/crates/durable-core/src/start.rs
@@ -1,10 +1,8 @@
-use std::io::Write;
-
 // PanicInfo has been deprecated and renamed to PanicHookInfo but only in 1.82
 // or newer.
 //
 // Use a type alias here to avoid the deprecation warning.
-#[allow(deprecated)]
+#[allow(deprecated, dead_code)]
 type PanicInfo<'a> = std::panic::PanicInfo<'a>;
 
 extern "C" {
@@ -14,12 +12,14 @@ extern "C" {
 
 #[no_mangle]
 extern "C" fn durable_ctor() {
-    #[cfg(target_arch = "wasm")]
+    #[cfg(target_arch = "wasm32")]
     std::panic::set_hook(Box::new(durable_panic_hook))
 }
 
-#[cfg(target_arch = "wasm")]
+#[cfg(target_arch = "wasm32")]
 fn durable_panic_hook(info: &PanicInfo) {
+    use std::io::Write;
+
     #[used]
     static __UNUSED_LINK_HACK: unsafe extern "C" fn() = durable_ctor_wrapper;
 


### PR DESCRIPTION
Normally this doesn't appear to cause an issue but it does appear to happen occasionally when compiling with lld.