### PR TITLE
Update to wasmtime 42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,16 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli",
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9698bf0769c641b18618039fe2ebd41eb3541f98433000f64e663fab7cea2c87"
+dependencies = [
+ "gimli 0.33.0",
 ]
 
 [[package]]
@@ -235,7 +244,7 @@ version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "addr2line",
+ "addr2line 0.25.1",
  "cfg-if",
  "libc",
  "miniz_oxide",
@@ -564,46 +573,47 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0377b13bf002a0774fcccac4f1102a10f04893d24060cf4b7350c87e4cbb647c"
+checksum = "40630d663279bc855bff805d6f5e8a0b6a1867f9df95b010511ac6dc894e9395"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa027979140d023b25bf7509fb7ede3a54c3d3871fb5ead4673c4b633f671a2"
+checksum = "3ee6aec5ceb55e5fdbcf7ef677d7c7195531360ff181ce39b2b31df11d57305f"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618e4da87d9179a70b3c2f664451ca8898987aa6eb9f487d16988588b5d8cc40"
+checksum = "9a92d78cc3f087d7e7073828f08d98c7074a3a062b6b29a1b7783ce74305685e"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db53764b5dad233b37b8f5dc54d3caa9900c54579195e00f17ea21f03f71aaa7"
+checksum = "edcc73d756f2e0d7eda6144fe64a2bc69c624de893cb1be51f1442aed77881d2"
 dependencies = [
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae927f1d8c0abddaa863acd201471d56e7fc6c3925104f4861ed4dc3e28b421"
+checksum = "683d94c2cd0d73b41369b88da1129589bc3a2d99cf49979af1d14751f35b7a1b"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -614,8 +624,9 @@ dependencies = [
  "cranelift-control",
  "cranelift-entity",
  "cranelift-isle",
- "gimli",
+ "gimli 0.33.0",
  "hashbrown 0.15.5",
+ "libm",
  "log",
  "pulley-interpreter",
  "regalloc2",
@@ -623,14 +634,14 @@ dependencies = [
  "serde",
  "smallvec",
  "target-lexicon",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fcf1e3e6757834bd2584f4cbff023fcc198e9279dcb5d684b4bb27a9b19f54"
+checksum = "235da0e52ee3a0052d0e944c3470ff025b1f4234f6ec4089d3109f2d2ffa6cbd"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -641,35 +652,36 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205dcb9e6ccf9d368b7466be675ff6ee54a63e36da6fe20e72d45169cf6fd254"
+checksum = "20c07c6c440bd1bf920ff7597a1e743ede1f68dcd400730bd6d389effa7662af"
 
 [[package]]
 name = "cranelift-control"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "108eca9fcfe86026054f931eceaf57b722c1b97464bf8265323a9b5877238817"
+checksum = "8797c022e02521901e1aee483dea3ed3c67f2bf0a26405c9dd48e8ee7a70944b"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d96496910065d3165f84ff8e1e393916f4c086f88ac8e1b407678bc78735aa"
+checksum = "59d8e72637246edd2cba337939850caa8b201f6315925ec4c156fdd089999699"
 dependencies = [
  "cranelift-bitset",
  "serde",
  "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e303983ad7e23c850f24d9c41fc3cb346e1b930f066d3966545e4c98dac5c9fb"
+checksum = "4c31db0085c3dfa131e739c3b26f9f9c84d69a9459627aac1ac4ef8355e3411b"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -679,15 +691,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24b0cf8d867d891245836cac7abafb0a5b0ea040a019d720702b3b8bcba40bfa"
+checksum = "524d804c1ebd8c542e6f64e71aa36934cec17c5da4a9ae3799796220317f5d23"
 
 [[package]]
 name = "cranelift-native"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24b641e315443e27807b69c440fe766737d7e718c68beb665a2d69259c77bf3"
+checksum = "dc9598f02540e382e1772416eba18e93c5275b746adbbf06ac1f3cf149415270"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -696,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.128.3"
+version = "0.129.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e378a54e7168a689486d67ee1f818b7e5356e54ae51a1d7a53f4f13f7f8b7a"
+checksum = "d953932541249c91e3fa70a75ff1e52adc62979a2a8132145d4b9b3e6d1a9b6a"
 
 [[package]]
 name = "crc"
@@ -1216,12 +1228,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,8 +1498,15 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
- "fallible-iterator",
+ "fnv",
+ "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "stable_deref_trait",
 ]
@@ -2596,21 +2609,21 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01051a5b172e07f9197b85060e6583b942aec679dac08416647bf7e7dc916b65"
+checksum = "bc2d61e068654529dc196437f8df0981db93687fdc67dec6a5de92363120b9da"
 dependencies = [
  "cranelift-bitset",
  "log",
  "pulley-macros",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "pulley-macros"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cf194f5b1a415ef3a44ee35056f4009092cc4038a9f7e3c7c1e392f48ee7dbb"
+checksum = "c3f210c61b6ecfaebbba806b6d9113a222519d4e5cc4ab2d5ecca047bb7927ae"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4138,9 +4151,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.243.0"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af801b6f36459023eaec63fdbaedad2fd5a4ab7dc74ecc110a8b5d375c5775e4"
+checksum = "92cda9c76ca8dcac01a8b497860c2cb15cd6f216dc07060517df5abbe82512ac"
 dependencies = [
  "anyhow",
  "heck",
@@ -4152,19 +4165,9 @@ dependencies = [
  "serde_derive",
  "serde_yaml",
  "smallvec",
- "wasm-encoder 0.243.0",
- "wasmparser 0.243.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
  "wat",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55db9c896d70bd9fa535ce83cd4e1f2ec3726b0edd2142079f594fc3be1cb35"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.243.0",
 ]
 
 [[package]]
@@ -4214,19 +4217,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d8db401b0528ec316dfbe579e6ab4152d61739cfe076706d2009127970159d"
-dependencies = [
- "bitflags 2.11.0",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
@@ -4235,6 +4225,7 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
+ "serde",
 ]
 
 [[package]]
@@ -4250,23 +4241,22 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.243.0"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2b6035559e146114c29a909a3232928ee488d6507a1504d8934e8607b36d7b"
+checksum = "09390d7b2bd7b938e563e4bff10aa345ef2e27a3bc99135697514ef54495e68f"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.243.0",
+ "wasmparser 0.244.0",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19f56cece843fa95dd929f5568ff8739c7e3873b530ceea9eda2aa02a0b4142"
+checksum = "39bef52be4fb4c5b47d36f847172e896bc94b35c9c6a6f07117686bd16ed89a7"
 dependencies = [
- "addr2line",
- "anyhow",
+ "addr2line 0.26.0",
  "async-trait",
  "bitflags 2.11.0",
  "bumpalo",
@@ -4275,9 +4265,7 @@ dependencies = [
  "encoding_rs",
  "futures",
  "fxprof-processed-profile",
- "gimli",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "gimli 0.33.0",
  "ittapi",
  "libc",
  "log",
@@ -4297,18 +4285,17 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.243.0",
- "wasmparser 0.243.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
  "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
  "wasmtime-internal-fiber",
  "wasmtime-internal-jit-debug",
  "wasmtime-internal-jit-icache-coherence",
- "wasmtime-internal-math",
- "wasmtime-internal-slab",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
  "wasmtime-internal-winch",
@@ -4318,15 +4305,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf9dff572c950258548cbbaf39033f68f8dcd0b43b22e80def9fe12d532d3e5"
+checksum = "bb637d5aa960ac391ca5a4cbf3e45807632e56beceeeb530e14dfa67fdfccc62"
 dependencies = [
  "anyhow",
  "cpp_demangle",
  "cranelift-bitset",
  "cranelift-entity",
- "gimli",
+ "gimli 0.33.0",
+ "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "log",
  "object",
@@ -4337,17 +4325,18 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.243.0",
- "wasmparser 0.243.0",
+ "wasm-encoder 0.244.0",
+ "wasmparser 0.244.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f52a985f5b5dae53147fc596f3a313c334e2c24fd1ba708634e1382f6ecd727"
+checksum = "4ab6c428c610ae3e7acd25ca2681b4d23672c50d8769240d9dda99b751d4deec"
 dependencies = [
  "base64 0.22.1",
  "directories-next",
@@ -4365,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7920dc7dcb608352f5fe93c52582e65075b7643efc5dac3fc717c1645a8d29a0"
+checksum = "ca768b11d5e7de017e8c3d4d444da6b4ce3906f565bcbc253d76b4ecbb5d2869"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4375,20 +4364,30 @@ dependencies = [
  "syn",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.243.0",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "066f5aed35aa60580a2ac0df145c0f0d4b04319862fee1d6036693e1cca43a12"
+checksum = "763f504faf96c9b409051e96a1434655eea7f56a90bed9cb1e22e22c941253fd"
+
+[[package]]
+name = "wasmtime-internal-core"
+version = "42.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a4a3f055a804a2f3d86e816a9df78a8fa57762212a8506164959224a40cd48"
+dependencies = [
+ "anyhow",
+ "libm",
+]
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb8002dc415b7773d7949ee360c05ee8f91627ec25a7a0b01ee03831bdfdda1"
+checksum = "55154a91d22ad51f9551124ce7fb49ddddc6a82c4910813db4c790c97c9ccf32"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4396,7 +4395,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "cranelift-native",
- "gimli",
+ "gimli 0.33.0",
  "itertools",
  "log",
  "object",
@@ -4404,18 +4403,18 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.243.0",
+ "wasmparser 0.244.0",
  "wasmtime-environ",
- "wasmtime-internal-math",
+ "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9c562c5a272bc9f615d8f0c085a4360bafa28eef9aa5947e63d204b1129b22"
+checksum = "05decfad1021ad2efcca5c1be9855acb54b6ee7158ac4467119b30b7481508e3"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4428,9 +4427,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db673148f26e1211db3913c12c75594be9e3858a71fa297561e9162b1a49cfb0"
+checksum = "924980c50427885fd4feed2049b88380178e567768aaabf29045b02eb262eaa7"
 dependencies = [
  "cc",
  "object",
@@ -4440,36 +4439,21 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bada5ca1cc47df7d14100e2254e187c2486b426df813cea2dd2553a7469f7674"
+checksum = "c57d24e8d1334a0e5a8b600286ffefa1fc4c3e8176b110dff6fbc1f43c4a599b"
 dependencies = [
- "anyhow",
  "cfg-if",
  "libc",
+ "wasmtime-internal-core",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "wasmtime-internal-math"
-version = "41.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6f615d528eda9adc6eefb062135f831b5215c348f4c3ec3e143690c730605b"
-dependencies = [
- "libm",
-]
-
-[[package]]
-name = "wasmtime-internal-slab"
-version = "41.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da169d4f789b586e1b2612ba8399c653ed5763edf3e678884ba785bb151d018f"
-
-[[package]]
 name = "wasmtime-internal-unwinder"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4888301f3393e4e8c75c938cce427293fade300fee3fc8fd466fdf3e54ae068e"
+checksum = "3a1a144bd4393593a868ba9df09f34a6a360cb5db6e71815f20d3f649c6e6735"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4480,9 +4464,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ba3124cc2cbcd362672f9f077303ccc4cd61daa908f73447b7fdaece75ff9f"
+checksum = "9a6948b56bb00c62dbd205ea18a4f1ceccbe1e4b8479651fdb0bab2553790f20"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4491,16 +4475,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a4182515dabba776656de4ebd62efad03399e261cf937ecccb838ce8823534"
+checksum = "9130b3ab6fb01be80b27b9a2c84817af29ae8224094f2503d2afa9fea5bf9d00"
 dependencies = [
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.0",
  "log",
  "object",
  "target-lexicon",
- "wasmparser 0.243.0",
+ "wasmparser 0.244.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -4508,15 +4492,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87acbd416227cdd279565ba49e57cf7f08d112657c3b3f39b70250acdfd094fe"
+checksum = "102d0d70dbfede00e4cc9c24e86df6d32c03bf6f5ad06b5d6c76b0a4a5004c4a"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
  "heck",
  "indexmap 2.13.0",
- "wit-parser 0.243.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4618,22 +4602,21 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "41.0.3"
+version = "42.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f31dcfdfaf9d6df9e1124d7c8ee6fc29af5b99b89d11ae731c138e0f5bd77b"
+checksum = "1977857998e4dd70d26e2bfc0618a9684a2fb65b1eca174dc13f3b3e9c2159ca"
 dependencies = [
- "anyhow",
  "cranelift-assembler-x64",
  "cranelift-codegen",
- "gimli",
+ "gimli 0.33.0",
  "regalloc2",
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.243.0",
+ "wasmparser 0.244.0",
  "wasmtime-environ",
+ "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
- "wasmtime-internal-math",
 ]
 
 [[package]]
@@ -4954,7 +4937,7 @@ checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser 0.244.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -5010,25 +4993,7 @@ dependencies = [
  "wasm-encoder 0.244.0",
  "wasm-metadata",
  "wasmparser 0.244.0",
- "wit-parser 0.244.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.243.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df983a8608e513d8997f435bb74207bf0933d0e49ca97aa9d8a6157164b9b7fc"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.13.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.243.0",
+ "wit-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ durable-migrate = { version = "0.1.0", registry = "iop-systems", path = "crates/
 durable-runtime = { version = "0.7.0", registry = "iop-systems", path = "crates/durable-runtime" }
 durable-bindgen = { version = "0.1.2", registry = "iop-systems", path = "crates/durable-bindgen" }
 
-wasmtime         = { version = "41.0" }
+wasmtime         = { version = "42.0", features = ["anyhow"] }
 wit-bindgen-core = { version = "0.51.0" }
 wit-bindgen-rust = { version = "0.51.0" }
 wit-bindgen-rt   = { version = "0.44.0" }

--- a/crates/durable-runtime/src/lib.rs
+++ b/crates/durable-runtime/src/lib.rs
@@ -36,6 +36,8 @@ mod bindings {
         exports: {
             default: async | trappable
         },
+
+        anyhow: true,
     });
 }
 

--- a/crates/durable-runtime/src/plugin/durable/http.rs
+++ b/crates/durable-runtime/src/plugin/durable/http.rs
@@ -183,11 +183,7 @@ impl HostHttpRequest2 for Task {
         Ok(())
     }
 
-    async fn set_body(
-        &mut self,
-        res: Resource<HttpRequest2>,
-        body: Vec<u8>,
-    ) -> anyhow::Result<()> {
+    async fn set_body(&mut self, res: Resource<HttpRequest2>, body: Vec<u8>) -> anyhow::Result<()> {
         let request = self.resources.get_mut(res)?;
 
         HttpRequest2::set_body(request, body);

--- a/crates/durable-runtime/src/plugin/durable/http.rs
+++ b/crates/durable-runtime/src/plugin/durable/http.rs
@@ -40,32 +40,32 @@ impl Task {
 }
 
 impl HostHttpError2 for Task {
-    async fn message(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<String> {
+    async fn message(&mut self, res: Resource<HttpError2>) -> anyhow::Result<String> {
         let error = self.resources.get(res)?;
         Ok(error.to_string())
     }
 
-    async fn is_timeout(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<bool> {
+    async fn is_timeout(&mut self, res: Resource<HttpError2>) -> anyhow::Result<bool> {
         let error = self.resources.get(res)?;
         Ok(error.is_timeout())
     }
 
-    async fn is_builder(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<bool> {
+    async fn is_builder(&mut self, res: Resource<HttpError2>) -> anyhow::Result<bool> {
         let error = self.resources.get(res)?;
         Ok(error.is_builder())
     }
 
-    async fn is_request(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<bool> {
+    async fn is_request(&mut self, res: Resource<HttpError2>) -> anyhow::Result<bool> {
         let error = self.resources.get(res)?;
         Ok(error.is_request())
     }
 
-    async fn is_connect(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<bool> {
+    async fn is_connect(&mut self, res: Resource<HttpError2>) -> anyhow::Result<bool> {
         let error = self.resources.get(res)?;
         Ok(error.is_connect())
     }
 
-    async fn drop(&mut self, res: Resource<HttpError2>) -> wasmtime::Result<()> {
+    async fn drop(&mut self, res: Resource<HttpError2>) -> anyhow::Result<()> {
         self.resources.remove(res)?;
         Ok(())
     }
@@ -123,7 +123,7 @@ impl HostHttpRequest2 for Task {
         &mut self,
         method: String,
         url: String,
-    ) -> wasmtime::Result<Result<Resource<HttpRequest2>, Resource<HttpError2>>> {
+    ) -> anyhow::Result<Result<Resource<HttpRequest2>, Resource<HttpError2>>> {
         let config = self.state.config();
 
         Ok(match HttpRequest2::new(method, url, config) {
@@ -136,7 +136,7 @@ impl HostHttpRequest2 for Task {
         &mut self,
         res: Resource<HttpRequest2>,
         method: String,
-    ) -> wasmtime::Result<Result<(), Resource<HttpError2>>> {
+    ) -> anyhow::Result<Result<(), Resource<HttpError2>>> {
         let request = self.resources.get_mut(res)?;
 
         Ok(match HttpRequest2::set_method(request, &method) {
@@ -149,7 +149,7 @@ impl HostHttpRequest2 for Task {
         &mut self,
         res: Resource<HttpRequest2>,
         url: String,
-    ) -> wasmtime::Result<Result<(), Resource<HttpError2>>> {
+    ) -> anyhow::Result<Result<(), Resource<HttpError2>>> {
         let request = self.resources.get_mut(res)?;
 
         Ok(match HttpRequest2::set_url(request, &url) {
@@ -162,7 +162,7 @@ impl HostHttpRequest2 for Task {
         &mut self,
         res: Resource<HttpRequest2>,
         headers: Vec<HttpHeader>,
-    ) -> wasmtime::Result<Result<(), Resource<HttpError2>>> {
+    ) -> anyhow::Result<Result<(), Resource<HttpError2>>> {
         let request = self.resources.get_mut(res)?;
 
         Ok(match HttpRequest2::set_headers(request, &headers) {
@@ -175,7 +175,7 @@ impl HostHttpRequest2 for Task {
         &mut self,
         res: Resource<HttpRequest2>,
         timeout: u64,
-    ) -> wasmtime::Result<()> {
+    ) -> anyhow::Result<()> {
         let request = self.resources.get_mut(res)?;
         let config = self.state.config();
 
@@ -187,14 +187,14 @@ impl HostHttpRequest2 for Task {
         &mut self,
         res: Resource<HttpRequest2>,
         body: Vec<u8>,
-    ) -> wasmtime::Result<()> {
+    ) -> anyhow::Result<()> {
         let request = self.resources.get_mut(res)?;
 
         HttpRequest2::set_body(request, body);
         Ok(())
     }
 
-    async fn drop(&mut self, res: Resource<HttpRequest2>) -> wasmtime::Result<()> {
+    async fn drop(&mut self, res: Resource<HttpRequest2>) -> anyhow::Result<()> {
         self.resources.remove(res)?;
         Ok(())
     }
@@ -235,7 +235,7 @@ impl Host for Task {
     async fn fetch2(
         &mut self,
         request: Resource<HttpRequest2>,
-    ) -> wasmtime::Result<Result<HttpResponse, Resource<HttpError2>>> {
+    ) -> anyhow::Result<Result<HttpResponse, Resource<HttpError2>>> {
         self.state
             .assert_in_transaction("durable:http/http.fetch2")?;
 

--- a/crates/durable-runtime/src/plugin/durable/notify.rs
+++ b/crates/durable-runtime/src/plugin/durable/notify.rs
@@ -38,7 +38,7 @@ async fn poll_notification(
 }
 
 impl Host for Task {
-    async fn notification_blocking(&mut self) -> wasmtime::Result<Event> {
+    async fn notification_blocking(&mut self) -> anyhow::Result<Event> {
         if self.state.transaction().is_some() {
             anyhow::bail!(
                 "durable:core/notify.notification-blocking cannot be called from within a \
@@ -121,7 +121,7 @@ impl Host for Task {
     async fn notification_blocking_timeout(
         &mut self,
         timeout_ns: u64,
-    ) -> wasmtime::Result<Option<Event>> {
+    ) -> anyhow::Result<Option<Event>> {
         if self.state.transaction().is_some() {
             anyhow::bail!(
                 "durable:core/notify.notification-blocking-timeout cannot be called from within a \
@@ -240,7 +240,7 @@ impl Host for Task {
         task: i64,
         event: String,
         data: String,
-    ) -> wasmtime::Result<Result<(), NotifyError>> {
+    ) -> anyhow::Result<Result<(), NotifyError>> {
         if self.state.transaction().is_some() {
             anyhow::bail!("durable:core/notify.notify cannot be called from within a transaction");
         }

--- a/crates/durable-runtime/src/plugin/durable/sql/mod.rs
+++ b/crates/durable-runtime/src/plugin/durable/sql/mod.rs
@@ -45,7 +45,7 @@ where
 }
 
 impl sql::HostTypeInfo for Task {
-    async fn name(&mut self, res: Resource<sql::TypeInfo>) -> wasmtime::Result<String> {
+    async fn name(&mut self, res: Resource<sql::TypeInfo>) -> anyhow::Result<String> {
         use sqlx::TypeInfo;
 
         let tyinfo = self.resources.get(res)?;
@@ -56,7 +56,7 @@ impl sql::HostTypeInfo for Task {
         &mut self,
         a: Resource<sql::TypeInfo>,
         b: Resource<sql::TypeInfo>,
-    ) -> wasmtime::Result<bool> {
+    ) -> anyhow::Result<bool> {
         use sqlx::TypeInfo;
 
         let tya = self.resources.get(a)?;
@@ -69,7 +69,7 @@ impl sql::HostTypeInfo for Task {
         &mut self,
         a: Resource<sql::TypeInfo>,
         b: Resource<sql::TypeInfo>,
-    ) -> wasmtime::Result<bool> {
+    ) -> anyhow::Result<bool> {
         let tya = self.resources.get(a)?;
         let tyb = self.resources.get(b)?;
 
@@ -79,7 +79,7 @@ impl sql::HostTypeInfo for Task {
     async fn clone(
         &mut self,
         res: Resource<sql::TypeInfo>,
-    ) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    ) -> anyhow::Result<Resource<sql::TypeInfo>> {
         let tyinfo = self.resources.get(res)?.clone();
         self.resources.insert(tyinfo)
     }
@@ -87,7 +87,7 @@ impl sql::HostTypeInfo for Task {
     async fn serialize(
         &mut self,
         res: Resource<sql::TypeInfo>,
-    ) -> wasmtime::Result<Result<String, String>> {
+    ) -> anyhow::Result<Result<String, String>> {
         let tyinfo = self.resources.get(res)?;
         let json = serde_json::to_string(tyinfo).map_err(|e| e.to_string());
 
@@ -97,7 +97,7 @@ impl sql::HostTypeInfo for Task {
     async fn deserialize(
         &mut self,
         json: String,
-    ) -> wasmtime::Result<Result<Resource<sql::TypeInfo>, String>> {
+    ) -> anyhow::Result<Result<Resource<sql::TypeInfo>, String>> {
         let tyinfo: TypeInfoResource = match serde_json::from_str(&json) {
             Ok(tyinfo) => tyinfo,
             Err(e) => return Ok(Err(e.to_string())),
@@ -109,7 +109,7 @@ impl sql::HostTypeInfo for Task {
     async fn with_name(
         &mut self,
         name: String,
-    ) -> wasmtime::Result<Result<Resource<sql::TypeInfo>, String>> {
+    ) -> anyhow::Result<Result<Resource<sql::TypeInfo>, String>> {
         let pool = self.state.pool();
 
         let result = sqlx::query_scalar!(r#"SELECT $1::regtype::oid as "oid!""#, &name as &str)
@@ -132,154 +132,154 @@ impl sql::HostTypeInfo for Task {
         })?))
     }
 
-    async fn boolean(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn boolean(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<bool as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn float4(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn float4(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<f32 as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn float8(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn float8(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<f64 as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn int1(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn int1(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<i8 as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn int2(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn int2(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<i16 as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn int4(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn int4(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<i32 as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn int8(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn int8(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<i64 as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn text(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn text(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<String as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn bytea(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn bytea(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<u8> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn timestamptz(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn timestamptz(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<DateTime<Utc> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn timestamp(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn timestamp(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<NaiveDateTime as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn uuid(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn uuid(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Uuid as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn jsonb(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn jsonb(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Json<()> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn inet(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn inet(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<IpNetwork as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn boolean_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn boolean_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<bool> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn float4_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn float4_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<f32> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn float8_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn float8_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<f64> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn int1_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn int1_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<i8> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn int2_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn int2_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<i16> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn int4_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn int4_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<i32> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn int8_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn int8_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<i64> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn text_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn text_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<String> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn bytea_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn bytea_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<Vec<u8>> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn timestamptz_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn timestamptz_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<DateTime<Utc>> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn timestamp_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn timestamp_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<NaiveDateTime> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn uuid_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn uuid_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<Uuid> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn jsonb_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn jsonb_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<Json<()>> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn inet_array(&mut self) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    async fn inet_array(&mut self) -> anyhow::Result<Resource<sql::TypeInfo>> {
         self.resources
             .insert(<Vec<IpNetwork> as sqlx::Type<sqlx::Postgres>>::type_info().into())
     }
 
-    async fn drop(&mut self, rep: Resource<sql::TypeInfo>) -> wasmtime::Result<()> {
+    async fn drop(&mut self, rep: Resource<sql::TypeInfo>) -> anyhow::Result<()> {
         self.resources.remove(rep)?;
         Ok(())
     }
 }
 
 impl sql::HostValue for Task {
-    async fn is_null(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<bool> {
+    async fn is_null(&mut self, res: Resource<sql::Value>) -> anyhow::Result<bool> {
         let value = self.resources.get(res)?;
         Ok(value.value.is_null())
     }
@@ -287,13 +287,13 @@ impl sql::HostValue for Task {
     async fn type_info(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Resource<sql::TypeInfo>> {
+    ) -> anyhow::Result<Resource<sql::TypeInfo>> {
         let value = self.resources.get(res)?;
         let tyinfo = value.type_info.clone();
         self.resources.insert(tyinfo)
     }
 
-    async fn clone(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn clone(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Resource<sql::Value>> {
         let value = self.resources.get(res)?.clone();
         self.resources.insert(value)
     }
@@ -301,7 +301,7 @@ impl sql::HostValue for Task {
     async fn serialize(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Result<String, String>> {
+    ) -> anyhow::Result<Result<String, String>> {
         let tyinfo = self.resources.get(res)?;
         let json = serde_json::to_string(tyinfo).map_err(|e| e.to_string());
 
@@ -311,7 +311,7 @@ impl sql::HostValue for Task {
     async fn deserialize(
         &mut self,
         json: String,
-    ) -> wasmtime::Result<Result<Resource<sql::Value>, String>> {
+    ) -> anyhow::Result<Result<Resource<sql::Value>, String>> {
         let value: ValueResource = match serde_json::from_str(&json) {
             Ok(tyinfo) => tyinfo,
             Err(e) => return Ok(Err(e.to_string())),
@@ -320,7 +320,7 @@ impl sql::HostValue for Task {
         Ok(Ok(self.resources.insert(value)?))
     }
 
-    async fn as_boolean(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Option<bool>> {
+    async fn as_boolean(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Option<bool>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -329,7 +329,7 @@ impl sql::HostValue for Task {
         })
     }
 
-    async fn as_float4(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Option<f32>> {
+    async fn as_float4(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Option<f32>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -338,7 +338,7 @@ impl sql::HostValue for Task {
         })
     }
 
-    async fn as_float8(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Option<f64>> {
+    async fn as_float8(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Option<f64>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -347,7 +347,7 @@ impl sql::HostValue for Task {
         })
     }
 
-    async fn as_int1(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Option<i8>> {
+    async fn as_int1(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Option<i8>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -356,7 +356,7 @@ impl sql::HostValue for Task {
         })
     }
 
-    async fn as_int2(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Option<i16>> {
+    async fn as_int2(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Option<i16>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -365,7 +365,7 @@ impl sql::HostValue for Task {
         })
     }
 
-    async fn as_int4(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Option<i32>> {
+    async fn as_int4(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Option<i32>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -374,7 +374,7 @@ impl sql::HostValue for Task {
         })
     }
 
-    async fn as_int8(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Option<i64>> {
+    async fn as_int8(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Option<i64>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -383,7 +383,7 @@ impl sql::HostValue for Task {
         })
     }
 
-    async fn as_text(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Option<String>> {
+    async fn as_text(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Option<String>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -392,7 +392,7 @@ impl sql::HostValue for Task {
         })
     }
 
-    async fn as_bytea(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Option<Vec<u8>>> {
+    async fn as_bytea(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Option<Vec<u8>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -404,7 +404,7 @@ impl sql::HostValue for Task {
     async fn as_timestamptz(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<sql::Timestamptz>> {
+    ) -> anyhow::Result<Option<sql::Timestamptz>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -416,7 +416,7 @@ impl sql::HostValue for Task {
     async fn as_timestamp(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<sql::Timestamp>> {
+    ) -> anyhow::Result<Option<sql::Timestamp>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -425,7 +425,7 @@ impl sql::HostValue for Task {
         })
     }
 
-    async fn as_uuid(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Option<sql::Uuid>> {
+    async fn as_uuid(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Option<sql::Uuid>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -434,7 +434,7 @@ impl sql::HostValue for Task {
         })
     }
 
-    async fn as_json(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<Option<String>> {
+    async fn as_json(&mut self, res: Resource<sql::Value>) -> anyhow::Result<Option<String>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -446,7 +446,7 @@ impl sql::HostValue for Task {
     async fn as_inet(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<sql::IpNetwork>> {
+    ) -> anyhow::Result<Option<sql::IpNetwork>> {
         let value = self.resources.get(res)?;
 
         Ok(match value.value {
@@ -458,7 +458,7 @@ impl sql::HostValue for Task {
     async fn as_boolean_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<bool>>> {
+    ) -> anyhow::Result<Option<Vec<bool>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -470,7 +470,7 @@ impl sql::HostValue for Task {
     async fn as_float4_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<f32>>> {
+    ) -> anyhow::Result<Option<Vec<f32>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -482,7 +482,7 @@ impl sql::HostValue for Task {
     async fn as_float8_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<f64>>> {
+    ) -> anyhow::Result<Option<Vec<f64>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -494,7 +494,7 @@ impl sql::HostValue for Task {
     async fn as_int1_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<i8>>> {
+    ) -> anyhow::Result<Option<Vec<i8>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -506,7 +506,7 @@ impl sql::HostValue for Task {
     async fn as_int2_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<i16>>> {
+    ) -> anyhow::Result<Option<Vec<i16>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -518,7 +518,7 @@ impl sql::HostValue for Task {
     async fn as_int4_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<i32>>> {
+    ) -> anyhow::Result<Option<Vec<i32>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -530,7 +530,7 @@ impl sql::HostValue for Task {
     async fn as_int8_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<i64>>> {
+    ) -> anyhow::Result<Option<Vec<i64>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -542,7 +542,7 @@ impl sql::HostValue for Task {
     async fn as_text_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<String>>> {
+    ) -> anyhow::Result<Option<Vec<String>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -554,7 +554,7 @@ impl sql::HostValue for Task {
     async fn as_bytea_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<Vec<u8>>>> {
+    ) -> anyhow::Result<Option<Vec<Vec<u8>>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -566,7 +566,7 @@ impl sql::HostValue for Task {
     async fn as_timestamptz_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<sql::Timestamptz>>> {
+    ) -> anyhow::Result<Option<Vec<sql::Timestamptz>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -578,7 +578,7 @@ impl sql::HostValue for Task {
     async fn as_timestamp_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<sql::Timestamp>>> {
+    ) -> anyhow::Result<Option<Vec<sql::Timestamp>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -590,7 +590,7 @@ impl sql::HostValue for Task {
     async fn as_uuid_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<sql::Uuid>>> {
+    ) -> anyhow::Result<Option<Vec<sql::Uuid>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -602,7 +602,7 @@ impl sql::HostValue for Task {
     async fn as_json_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<String>>> {
+    ) -> anyhow::Result<Option<Vec<String>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -614,7 +614,7 @@ impl sql::HostValue for Task {
     async fn as_inet_array(
         &mut self,
         res: Resource<sql::Value>,
-    ) -> wasmtime::Result<Option<Vec<sql::IpNetwork>>> {
+    ) -> anyhow::Result<Option<Vec<sql::IpNetwork>>> {
         let value = self.resources.get(res)?;
 
         Ok(match &value.value {
@@ -626,7 +626,7 @@ impl sql::HostValue for Task {
     async fn null(
         &mut self,
         tyinfo: Resource<sql::TypeInfo>,
-    ) -> wasmtime::Result<Resource<sql::Value>> {
+    ) -> anyhow::Result<Resource<sql::Value>> {
         let tyinfo = self.resources.remove(tyinfo)?;
         let value = ValueResource {
             type_info: tyinfo,
@@ -636,7 +636,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn boolean(&mut self, value: bool) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn boolean(&mut self, value: bool) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Boolean(value),
@@ -645,7 +645,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn float4(&mut self, value: f32) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn float4(&mut self, value: f32) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Float4(value),
@@ -654,7 +654,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn float8(&mut self, value: f64) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn float8(&mut self, value: f64) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Float8(value),
@@ -663,7 +663,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn int1(&mut self, value: i8) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn int1(&mut self, value: i8) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Int1(value),
@@ -672,7 +672,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn int2(&mut self, value: i16) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn int2(&mut self, value: i16) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Int2(value),
@@ -681,7 +681,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn int4(&mut self, value: i32) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn int4(&mut self, value: i32) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Int4(value),
@@ -690,7 +690,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn int8(&mut self, value: i64) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn int8(&mut self, value: i64) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Int8(value),
@@ -699,7 +699,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn text(&mut self, value: String) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn text(&mut self, value: String) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Text(value),
@@ -708,7 +708,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn bytea(&mut self, value: Vec<u8>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn bytea(&mut self, value: Vec<u8>) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Bytea(value),
@@ -720,7 +720,7 @@ impl sql::HostValue for Task {
     async fn timestamptz(
         &mut self,
         value: sql::Timestamptz,
-    ) -> wasmtime::Result<Resource<sql::Value>> {
+    ) -> anyhow::Result<Resource<sql::Value>> {
         let value: DateTime<FixedOffset> = value.into();
         let value = ValueResource {
             type_info: type_info(&value),
@@ -730,7 +730,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn timestamp(&mut self, value: sql::Timestamp) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn timestamp(&mut self, value: sql::Timestamp) -> anyhow::Result<Resource<sql::Value>> {
         let value: NaiveDateTime = value.into();
         let value = ValueResource {
             type_info: type_info(&value),
@@ -740,7 +740,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn uuid(&mut self, value: sql::Uuid) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn uuid(&mut self, value: sql::Uuid) -> anyhow::Result<Resource<sql::Value>> {
         let value = value.into();
         let value = ValueResource {
             type_info: type_info(&value),
@@ -750,7 +750,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn jsonb(&mut self, value: String) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn jsonb(&mut self, value: String) -> anyhow::Result<Resource<sql::Value>> {
         let value = value.into_boxed_str();
         let value: Box<RawValue> = unsafe { std::mem::transmute(value) };
         let value = ValueResource {
@@ -764,7 +764,7 @@ impl sql::HostValue for Task {
     async fn inet(
         &mut self,
         value: sql::IpNetwork,
-    ) -> wasmtime::Result<Result<Resource<sql::Value>, String>> {
+    ) -> anyhow::Result<Result<Resource<sql::Value>, String>> {
         let value: IpNetwork = match value.try_into() {
             Ok(value) => value,
             Err(e) => return Ok(Err(e.to_string())),
@@ -781,7 +781,7 @@ impl sql::HostValue for Task {
         &mut self,
         value: String,
         tyinfo: Resource<sql::TypeInfo>,
-    ) -> wasmtime::Result<Resource<sql::Value>> {
+    ) -> anyhow::Result<Resource<sql::Value>> {
         let tyinfo = self.resources.get(tyinfo)?.clone();
         let value = ValueResource {
             type_info: tyinfo,
@@ -791,7 +791,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn boolean_array(&mut self, value: Vec<bool>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn boolean_array(&mut self, value: Vec<bool>) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::BooleanArray(value),
@@ -800,7 +800,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn float4_array(&mut self, value: Vec<f32>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn float4_array(&mut self, value: Vec<f32>) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Float4Array(value),
@@ -809,7 +809,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn float8_array(&mut self, value: Vec<f64>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn float8_array(&mut self, value: Vec<f64>) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Float8Array(value),
@@ -818,7 +818,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn int1_array(&mut self, value: Vec<i8>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn int1_array(&mut self, value: Vec<i8>) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Int1Array(value),
@@ -827,7 +827,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn int2_array(&mut self, value: Vec<i16>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn int2_array(&mut self, value: Vec<i16>) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Int2Array(value),
@@ -836,7 +836,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn int4_array(&mut self, value: Vec<i32>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn int4_array(&mut self, value: Vec<i32>) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Int4Array(value),
@@ -845,7 +845,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn int8_array(&mut self, value: Vec<i64>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn int8_array(&mut self, value: Vec<i64>) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::Int8Array(value),
@@ -854,7 +854,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn text_array(&mut self, value: Vec<String>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn text_array(&mut self, value: Vec<String>) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::TextArray(value),
@@ -863,7 +863,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn bytea_array(&mut self, value: Vec<Vec<u8>>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn bytea_array(&mut self, value: Vec<Vec<u8>>) -> anyhow::Result<Resource<sql::Value>> {
         let value = ValueResource {
             type_info: type_info(&value),
             value: Value::ByteaArray(value),
@@ -875,7 +875,7 @@ impl sql::HostValue for Task {
     async fn timestamptz_array(
         &mut self,
         value: Vec<sql::Timestamptz>,
-    ) -> wasmtime::Result<Resource<sql::Value>> {
+    ) -> anyhow::Result<Resource<sql::Value>> {
         let value = value.into_iter().map(From::from).collect();
         let value = ValueResource {
             type_info: type_info(&value),
@@ -888,7 +888,7 @@ impl sql::HostValue for Task {
     async fn timestamp_array(
         &mut self,
         value: Vec<sql::Timestamp>,
-    ) -> wasmtime::Result<Resource<sql::Value>> {
+    ) -> anyhow::Result<Resource<sql::Value>> {
         let value = value.into_iter().map(From::from).collect();
         let value = ValueResource {
             type_info: type_info(&value),
@@ -901,7 +901,7 @@ impl sql::HostValue for Task {
     async fn uuid_array(
         &mut self,
         value: Vec<sql::Uuid>,
-    ) -> wasmtime::Result<Resource<sql::Value>> {
+    ) -> anyhow::Result<Resource<sql::Value>> {
         let value = value.into_iter().map(From::from).collect();
         let value = ValueResource {
             type_info: type_info(&value),
@@ -911,7 +911,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn jsonb_array(&mut self, value: Vec<String>) -> wasmtime::Result<Resource<sql::Value>> {
+    async fn jsonb_array(&mut self, value: Vec<String>) -> anyhow::Result<Resource<sql::Value>> {
         let value = value
             .into_iter()
             .map(|json| {
@@ -932,7 +932,7 @@ impl sql::HostValue for Task {
     async fn inet_array(
         &mut self,
         values: Vec<sql::IpNetwork>,
-    ) -> wasmtime::Result<Result<Resource<sql::Value>, String>> {
+    ) -> anyhow::Result<Result<Resource<sql::Value>, String>> {
         let values: Vec<IpNetwork> = match values.into_iter().map(TryFrom::try_from).collect() {
             Ok(values) => values,
             Err(e) => return Ok(Err(e.to_string())),
@@ -949,7 +949,7 @@ impl sql::HostValue for Task {
         &mut self,
         value: Vec<String>,
         tyinfo: Resource<sql::TypeInfo>,
-    ) -> wasmtime::Result<Resource<sql::Value>> {
+    ) -> anyhow::Result<Resource<sql::Value>> {
         let tyinfo = self.resources.get(tyinfo)?.clone();
         let value = ValueResource {
             type_info: tyinfo,
@@ -959,7 +959,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn drop(&mut self, res: Resource<sql::Value>) -> wasmtime::Result<()> {
+    async fn drop(&mut self, res: Resource<sql::Value>) -> anyhow::Result<()> {
         self.resources.remove(res)?;
         Ok(())
     }
@@ -1024,7 +1024,7 @@ impl Host for Task {
         })
     }
 
-    async fn fetch(&mut self) -> wasmtime::Result<Option<Result<sql::QueryResult, sql::Error>>> {
+    async fn fetch(&mut self) -> anyhow::Result<Option<Result<sql::QueryResult, sql::Error>>> {
         let txn = self.state.assert_in_transaction("durable::sql::query")?;
         let stream = match txn.stream() {
             Some(stream) => stream,

--- a/crates/durable-runtime/src/plugin/durable/sql/mod.rs
+++ b/crates/durable-runtime/src/plugin/durable/sql/mod.rs
@@ -898,10 +898,7 @@ impl sql::HostValue for Task {
         self.resources.insert(value)
     }
 
-    async fn uuid_array(
-        &mut self,
-        value: Vec<sql::Uuid>,
-    ) -> anyhow::Result<Resource<sql::Value>> {
+    async fn uuid_array(&mut self, value: Vec<sql::Uuid>) -> anyhow::Result<Resource<sql::Value>> {
         let value = value.into_iter().map(From::from).collect();
         let value = ValueResource {
             type_info: type_info(&value),

--- a/crates/durable-runtime/src/plugin/wasi/cli.rs
+++ b/crates/durable-runtime/src/plugin/wasi/cli.rs
@@ -6,21 +6,21 @@ use crate::error::TaskStatus;
 use crate::task::Task;
 
 impl wasi::cli::environment::Host for Task {
-    async fn get_arguments(&mut self) -> wasmtime::Result<Vec<String>> {
+    async fn get_arguments(&mut self) -> anyhow::Result<Vec<String>> {
         Ok(Vec::new())
     }
 
-    async fn get_environment(&mut self) -> wasmtime::Result<Vec<(String, String)>> {
+    async fn get_environment(&mut self) -> anyhow::Result<Vec<(String, String)>> {
         Ok(Vec::new())
     }
 
-    async fn initial_cwd(&mut self) -> wasmtime::Result<Option<String>> {
+    async fn initial_cwd(&mut self) -> anyhow::Result<Option<String>> {
         Ok(None)
     }
 }
 
 impl wasi::cli::exit::Host for Task {
-    async fn exit(&mut self, status: Result<(), ()>) -> wasmtime::Result<()> {
+    async fn exit(&mut self, status: Result<(), ()>) -> anyhow::Result<()> {
         Err(match status {
             Ok(()) => anyhow::Error::new(TaskStatus::ExitSuccess),
             Err(()) => anyhow::Error::new(TaskStatus::ExitFailure),
@@ -29,19 +29,19 @@ impl wasi::cli::exit::Host for Task {
 }
 
 impl wasi::cli::stdin::Host for Task {
-    async fn get_stdin(&mut self) -> wasmtime::Result<Resource<InputStream>> {
+    async fn get_stdin(&mut self) -> anyhow::Result<Resource<InputStream>> {
         Ok(Resource::new_own(0))
     }
 }
 
 impl wasi::cli::stdout::Host for Task {
-    async fn get_stdout(&mut self) -> wasmtime::Result<Resource<OutputStream>> {
+    async fn get_stdout(&mut self) -> anyhow::Result<Resource<OutputStream>> {
         Ok(Resource::new_own(1))
     }
 }
 
 impl wasi::cli::stderr::Host for Task {
-    async fn get_stderr(&mut self) -> wasmtime::Result<Resource<OutputStream>> {
+    async fn get_stderr(&mut self) -> anyhow::Result<Resource<OutputStream>> {
         Ok(Resource::new_own(1))
     }
 }

--- a/crates/durable-runtime/src/plugin/wasi/clocks.rs
+++ b/crates/durable-runtime/src/plugin/wasi/clocks.rs
@@ -24,7 +24,7 @@ impl From<SerializableDateTime> for Datetime {
 }
 
 impl wasi::clocks::wall_clock::Host for Task {
-    async fn now(&mut self) -> wasmtime::Result<Datetime> {
+    async fn now(&mut self) -> anyhow::Result<Datetime> {
         let options = TransactionOptions::new("wasi:clocks/wall-clock.now");
         self.state
             .maybe_do_transaction_sync(options, |state| {
@@ -38,7 +38,7 @@ impl wasi::clocks::wall_clock::Host for Task {
             .await
     }
 
-    async fn resolution(&mut self) -> wasmtime::Result<Datetime> {
+    async fn resolution(&mut self) -> anyhow::Result<Datetime> {
         // The underlying clocks on the host don't necessarily have a consistent
         // resolution. This is especially true since the workflow may move between
         // hosts.
@@ -49,7 +49,7 @@ impl wasi::clocks::wall_clock::Host for Task {
 }
 
 impl wasi::clocks::monotonic_clock::Host for Task {
-    async fn now(&mut self) -> wasmtime::Result<Instant> {
+    async fn now(&mut self) -> anyhow::Result<Instant> {
         let options = TransactionOptions::new("wasi:clocks/monotonic-clock.now");
         self.state
             .maybe_do_transaction_sync(options, |state| {
@@ -62,7 +62,7 @@ impl wasi::clocks::monotonic_clock::Host for Task {
             .await
     }
 
-    async fn resolution(&mut self) -> wasmtime::Result<monotonic::Duration> {
+    async fn resolution(&mut self) -> anyhow::Result<monotonic::Duration> {
         // The underlying clocks on the host don't necessarily have a consistent
         // resolution. This is especially true since the workflow may move between
         // hosts.
@@ -71,7 +71,7 @@ impl wasi::clocks::monotonic_clock::Host for Task {
         Ok(1000)
     }
 
-    async fn subscribe_instant(&mut self, when: Instant) -> wasmtime::Result<Resource<Pollable>> {
+    async fn subscribe_instant(&mut self, when: Instant) -> anyhow::Result<Resource<Pollable>> {
         let txn = self.state.transaction().map(|txn| txn.index());
         let timeout = DateTime::from_timestamp((when / NS_PER_S) as i64, (when % NS_PER_S) as u32)
             .unwrap_or(DateTime::<Utc>::MAX_UTC);
@@ -85,7 +85,7 @@ impl wasi::clocks::monotonic_clock::Host for Task {
     async fn subscribe_duration(
         &mut self,
         when: monotonic::Duration,
-    ) -> wasmtime::Result<Resource<Pollable>> {
+    ) -> anyhow::Result<Resource<Pollable>> {
         let now = self.now().await?;
         self.subscribe_instant(now.saturating_add(when)).await
     }

--- a/crates/durable-runtime/src/plugin/wasi/filesystem.rs
+++ b/crates/durable-runtime/src/plugin/wasi/filesystem.rs
@@ -11,7 +11,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         &mut self,
         _: Resource<Descriptor>,
         _: Filesize,
-    ) -> wasmtime::Result<Result<Resource<InputStream>, ErrorCode>> {
+    ) -> anyhow::Result<Result<Resource<InputStream>, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.read-via-stream is not implemented")
     }
 
@@ -19,14 +19,14 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         &mut self,
         _: Resource<Descriptor>,
         _: Filesize,
-    ) -> wasmtime::Result<Result<Resource<OutputStream>, ErrorCode>> {
+    ) -> anyhow::Result<Result<Resource<OutputStream>, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.write-via-stream is not implemented")
     }
 
     async fn append_via_stream(
         &mut self,
         _: Resource<Descriptor>,
-    ) -> wasmtime::Result<Result<Resource<OutputStream>, ErrorCode>> {
+    ) -> anyhow::Result<Result<Resource<OutputStream>, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.append-via-stream is not implemented")
     }
 
@@ -36,28 +36,28 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         _: Filesize,
         _: Filesize,
         _: Advice,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.advise is not implemented")
     }
 
     async fn sync_data(
         &mut self,
         _: Resource<Descriptor>,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.sync-data is not implemented")
     }
 
     async fn get_flags(
         &mut self,
         _: Resource<Descriptor>,
-    ) -> wasmtime::Result<Result<DescriptorFlags, ErrorCode>> {
+    ) -> anyhow::Result<Result<DescriptorFlags, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.get-flags is not implemented")
     }
 
     async fn get_type(
         &mut self,
         _: Resource<Descriptor>,
-    ) -> wasmtime::Result<Result<DescriptorType, ErrorCode>> {
+    ) -> anyhow::Result<Result<DescriptorType, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.get-type is not implemented")
     }
 
@@ -65,7 +65,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         &mut self,
         _: Resource<Descriptor>,
         _: Filesize,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.set-size is not implemented")
     }
 
@@ -74,7 +74,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         _: Resource<Descriptor>,
         _: NewTimestamp,
         _: NewTimestamp,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.set-times is not implemented")
     }
 
@@ -83,7 +83,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         _: Resource<Descriptor>,
         _: Filesize,
         _: Filesize,
-    ) -> wasmtime::Result<Result<(Vec<u8>, bool), ErrorCode>> {
+    ) -> anyhow::Result<Result<(Vec<u8>, bool), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.read is not implemented")
     }
 
@@ -92,18 +92,18 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         _: Resource<Descriptor>,
         _: Vec<u8>,
         _: Filesize,
-    ) -> wasmtime::Result<Result<Filesize, ErrorCode>> {
+    ) -> anyhow::Result<Result<Filesize, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.write is not implemented")
     }
 
     async fn read_directory(
         &mut self,
         _: Resource<Descriptor>,
-    ) -> wasmtime::Result<Result<Resource<DirectoryEntryStream>, ErrorCode>> {
+    ) -> anyhow::Result<Result<Resource<DirectoryEntryStream>, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.read-directory is not implemented")
     }
 
-    async fn sync(&mut self, _: Resource<Descriptor>) -> wasmtime::Result<Result<(), ErrorCode>> {
+    async fn sync(&mut self, _: Resource<Descriptor>) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.sync is not implemented")
     }
 
@@ -111,14 +111,14 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         &mut self,
         _: Resource<Descriptor>,
         _: String,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.create-directory-at is not implemented")
     }
 
     async fn stat(
         &mut self,
         _: Resource<Descriptor>,
-    ) -> wasmtime::Result<Result<DescriptorStat, ErrorCode>> {
+    ) -> anyhow::Result<Result<DescriptorStat, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.stat is not implemented")
     }
 
@@ -127,7 +127,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         _: Resource<Descriptor>,
         _: PathFlags,
         _: String,
-    ) -> wasmtime::Result<Result<DescriptorStat, ErrorCode>> {
+    ) -> anyhow::Result<Result<DescriptorStat, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.stat-at is not implemented")
     }
 
@@ -138,7 +138,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         _: String,
         _: NewTimestamp,
         _: NewTimestamp,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.set-times-at is not implemented")
     }
 
@@ -149,7 +149,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         _: String,
         _: Resource<Descriptor>,
         _: String,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.link-at is not implemented")
     }
 
@@ -160,7 +160,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         _: String,
         _: OpenFlags,
         _: DescriptorFlags,
-    ) -> wasmtime::Result<Result<Resource<Descriptor>, ErrorCode>> {
+    ) -> anyhow::Result<Result<Resource<Descriptor>, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.open-at is not implemented")
     }
 
@@ -168,7 +168,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         &mut self,
         _: Resource<Descriptor>,
         _: String,
-    ) -> wasmtime::Result<Result<String, ErrorCode>> {
+    ) -> anyhow::Result<Result<String, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.readlink-at is not implemented")
     }
 
@@ -176,7 +176,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         &mut self,
         _: Resource<Descriptor>,
         _: String,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.remove-directory-at is not implemented")
     }
 
@@ -186,7 +186,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         _: String,
         _: Resource<Descriptor>,
         _: String,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.rename-at is not implemented")
     }
 
@@ -195,7 +195,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         _: Resource<Descriptor>,
         _: String,
         _: String,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.symlink-at is not implemented")
     }
 
@@ -203,7 +203,7 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         &mut self,
         _: Resource<Descriptor>,
         _: String,
-    ) -> wasmtime::Result<Result<(), ErrorCode>> {
+    ) -> anyhow::Result<Result<(), ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.unlink-file-at is not implemented")
     }
 
@@ -211,14 +211,14 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         &mut self,
         _: Resource<Descriptor>,
         _: Resource<Descriptor>,
-    ) -> wasmtime::Result<bool> {
+    ) -> anyhow::Result<bool> {
         anyhow::bail!("wasi:filesystem/types.descriptor.is-same-object is not implemented")
     }
 
     async fn metadata_hash(
         &mut self,
         _: Resource<Descriptor>,
-    ) -> wasmtime::Result<Result<MetadataHashValue, ErrorCode>> {
+    ) -> anyhow::Result<Result<MetadataHashValue, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.metadata-hash is not implemented")
     }
 
@@ -227,11 +227,11 @@ impl wasi::filesystem::types::HostDescriptor for Task {
         _: Resource<Descriptor>,
         _: PathFlags,
         _: String,
-    ) -> wasmtime::Result<Result<MetadataHashValue, ErrorCode>> {
+    ) -> anyhow::Result<Result<MetadataHashValue, ErrorCode>> {
         anyhow::bail!("wasi:filesystem/types.descriptor.metadata-hash-at is not implemented")
     }
 
-    async fn drop(&mut self, _: Resource<Descriptor>) -> wasmtime::Result<()> {
+    async fn drop(&mut self, _: Resource<Descriptor>) -> anyhow::Result<()> {
         Ok(())
     }
 }
@@ -240,13 +240,13 @@ impl wasi::filesystem::types::HostDirectoryEntryStream for Task {
     async fn read_directory_entry(
         &mut self,
         _: Resource<DirectoryEntryStream>,
-    ) -> wasmtime::Result<Result<Option<DirectoryEntry>, ErrorCode>> {
+    ) -> anyhow::Result<Result<Option<DirectoryEntry>, ErrorCode>> {
         anyhow::bail!(
             "wasi:filesystem/types.directory-entry-stream.read-directory-entry is not implemented"
         )
     }
 
-    async fn drop(&mut self, _: Resource<DirectoryEntryStream>) -> wasmtime::Result<()> {
+    async fn drop(&mut self, _: Resource<DirectoryEntryStream>) -> anyhow::Result<()> {
         Ok(())
     }
 }
@@ -255,14 +255,14 @@ impl wasi::filesystem::types::Host for Task {
     async fn filesystem_error_code(
         &mut self,
         _: Resource<Error>,
-    ) -> wasmtime::Result<Option<ErrorCode>> {
+    ) -> anyhow::Result<Option<ErrorCode>> {
         // The entire filesystem module is a stub so there are no fs error codes
         Ok(None)
     }
 }
 
 impl wasi::filesystem::preopens::Host for Task {
-    async fn get_directories(&mut self) -> wasmtime::Result<Vec<(Resource<Descriptor>, String)>> {
+    async fn get_directories(&mut self) -> anyhow::Result<Vec<(Resource<Descriptor>, String)>> {
         Ok(Vec::new())
     }
 }

--- a/crates/durable-runtime/src/plugin/wasi/io.rs
+++ b/crates/durable-runtime/src/plugin/wasi/io.rs
@@ -19,14 +19,14 @@ impl wasi::io::error::HostError for Task {
     async fn to_debug_string(
         &mut self,
         res: Resource<wasi::io::error::Error>,
-    ) -> wasmtime::Result<String> {
+    ) -> anyhow::Result<String> {
         let resources = self.plugins.expect::<WasiResources>();
         let error = &resources.errors[res.rep() as usize];
 
         Ok(error.to_string())
     }
 
-    async fn drop(&mut self, res: Resource<wasi::io::error::Error>) -> wasmtime::Result<()> {
+    async fn drop(&mut self, res: Resource<wasi::io::error::Error>) -> anyhow::Result<()> {
         let resources = self.plugins.expect_mut::<WasiResources>();
         resources.errors.remove(res.rep() as usize);
         Ok(())
@@ -44,7 +44,7 @@ impl wasi::io::streams::HostInputStream for Task {
         &mut self,
         _: Resource<InputStream>,
         _: u64,
-    ) -> wasmtime::Result<Result<Vec<u8>, StreamError>> {
+    ) -> anyhow::Result<Result<Vec<u8>, StreamError>> {
         // Workflows have no input streams. We model this by always indicating that
         // the stream is closed.
         Ok(Err(StreamError::Closed))
@@ -54,7 +54,7 @@ impl wasi::io::streams::HostInputStream for Task {
         &mut self,
         _: Resource<InputStream>,
         _: u64,
-    ) -> wasmtime::Result<Result<Vec<u8>, StreamError>> {
+    ) -> anyhow::Result<Result<Vec<u8>, StreamError>> {
         Ok(Err(StreamError::Closed))
     }
 
@@ -62,7 +62,7 @@ impl wasi::io::streams::HostInputStream for Task {
         &mut self,
         _: Resource<InputStream>,
         _: u64,
-    ) -> wasmtime::Result<Result<u64, StreamError>> {
+    ) -> anyhow::Result<Result<u64, StreamError>> {
         Ok(Err(StreamError::Closed))
     }
 
@@ -70,18 +70,18 @@ impl wasi::io::streams::HostInputStream for Task {
         &mut self,
         _: Resource<InputStream>,
         _: u64,
-    ) -> wasmtime::Result<Result<u64, StreamError>> {
+    ) -> anyhow::Result<Result<u64, StreamError>> {
         Ok(Err(StreamError::Closed))
     }
 
     async fn subscribe(
         &mut self,
         _: Resource<InputStream>,
-    ) -> wasmtime::Result<Resource<Pollable>> {
+    ) -> anyhow::Result<Resource<Pollable>> {
         Ok(Resource::new_own(u32::MAX))
     }
 
-    async fn drop(&mut self, _: Resource<InputStream>) -> wasmtime::Result<()> {
+    async fn drop(&mut self, _: Resource<InputStream>) -> anyhow::Result<()> {
         Ok(())
     }
 }
@@ -90,7 +90,7 @@ impl wasi::io::streams::HostOutputStream for Task {
     async fn check_write(
         &mut self,
         _: Resource<OutputStream>,
-    ) -> wasmtime::Result<Result<u64, StreamError>> {
+    ) -> anyhow::Result<Result<u64, StreamError>> {
         Ok(Ok(u64::MAX))
     }
 
@@ -98,7 +98,7 @@ impl wasi::io::streams::HostOutputStream for Task {
         &mut self,
         stream: Resource<OutputStream>,
         contents: Vec<u8>,
-    ) -> wasmtime::Result<Result<(), StreamError>> {
+    ) -> anyhow::Result<Result<(), StreamError>> {
         if stream.rep() != 1 {
             return Ok(Err(StreamError::Closed));
         }
@@ -120,14 +120,14 @@ impl wasi::io::streams::HostOutputStream for Task {
         &mut self,
         stream: Resource<OutputStream>,
         contents: Vec<u8>,
-    ) -> wasmtime::Result<Result<(), StreamError>> {
+    ) -> anyhow::Result<Result<(), StreamError>> {
         self.write(stream, contents).await
     }
 
     async fn flush(
         &mut self,
         stream: Resource<OutputStream>,
-    ) -> wasmtime::Result<Result<(), StreamError>> {
+    ) -> anyhow::Result<Result<(), StreamError>> {
         Ok(match stream.rep() {
             1 => Ok(()),
             _ => Err(StreamError::Closed),
@@ -137,14 +137,14 @@ impl wasi::io::streams::HostOutputStream for Task {
     async fn blocking_flush(
         &mut self,
         stream: Resource<OutputStream>,
-    ) -> wasmtime::Result<Result<(), StreamError>> {
+    ) -> anyhow::Result<Result<(), StreamError>> {
         self.flush(stream).await
     }
 
     async fn subscribe(
         &mut self,
         _: Resource<OutputStream>,
-    ) -> wasmtime::Result<Resource<Pollable>> {
+    ) -> anyhow::Result<Resource<Pollable>> {
         Ok(Resource::new_own(u32::MAX))
     }
 
@@ -152,7 +152,7 @@ impl wasi::io::streams::HostOutputStream for Task {
         &mut self,
         stream: Resource<OutputStream>,
         len: u64,
-    ) -> wasmtime::Result<Result<(), StreamError>> {
+    ) -> anyhow::Result<Result<(), StreamError>> {
         if stream.rep() != 1 {
             return Ok(Err(StreamError::Closed));
         }
@@ -176,7 +176,7 @@ impl wasi::io::streams::HostOutputStream for Task {
         &mut self,
         stream: Resource<OutputStream>,
         len: u64,
-    ) -> wasmtime::Result<Result<(), StreamError>> {
+    ) -> anyhow::Result<Result<(), StreamError>> {
         self.write_zeroes(stream, len).await
     }
 
@@ -185,7 +185,7 @@ impl wasi::io::streams::HostOutputStream for Task {
         _dst: Resource<OutputStream>,
         _src: Resource<InputStream>,
         _len: u64,
-    ) -> wasmtime::Result<Result<u64, StreamError>> {
+    ) -> anyhow::Result<Result<u64, StreamError>> {
         Ok(Err(StreamError::Closed))
     }
 
@@ -194,11 +194,11 @@ impl wasi::io::streams::HostOutputStream for Task {
         _dst: Resource<OutputStream>,
         _src: Resource<InputStream>,
         _len: u64,
-    ) -> wasmtime::Result<Result<u64, StreamError>> {
+    ) -> anyhow::Result<Result<u64, StreamError>> {
         Ok(Err(StreamError::Closed))
     }
 
-    async fn drop(&mut self, _: Resource<OutputStream>) -> wasmtime::Result<()> {
+    async fn drop(&mut self, _: Resource<OutputStream>) -> anyhow::Result<()> {
         Ok(())
     }
 }
@@ -206,7 +206,7 @@ impl wasi::io::streams::HostOutputStream for Task {
 impl wasi::io::streams::Host for Task {}
 
 impl wasi::io::poll::HostPollable for Task {
-    async fn ready(&mut self, pollable: Resource<Pollable>) -> wasmtime::Result<bool> {
+    async fn ready(&mut self, pollable: Resource<Pollable>) -> anyhow::Result<bool> {
         // Pollable is for a stream, so it is always ready.
         if pollable.rep() == u32::MAX {
             return Ok(true);
@@ -233,7 +233,7 @@ impl wasi::io::poll::HostPollable for Task {
             .await
     }
 
-    async fn block(&mut self, pollable: Resource<Pollable>) -> wasmtime::Result<()> {
+    async fn block(&mut self, pollable: Resource<Pollable>) -> anyhow::Result<()> {
         // Pollable is for a stream, so it is always ready.
         if pollable.rep() == u32::MAX {
             return Ok(());
@@ -295,7 +295,7 @@ impl wasi::io::poll::HostPollable for Task {
         Ok(())
     }
 
-    async fn drop(&mut self, pollable: Resource<Pollable>) -> wasmtime::Result<()> {
+    async fn drop(&mut self, pollable: Resource<Pollable>) -> anyhow::Result<()> {
         // All stream pollables are shared so no drops necessary.
         if pollable.rep() == u32::MAX {
             return Ok(());
@@ -309,7 +309,7 @@ impl wasi::io::poll::HostPollable for Task {
 }
 
 impl wasi::io::poll::Host for Task {
-    async fn poll(&mut self, pollables: Vec<Resource<Pollable>>) -> wasmtime::Result<Vec<u32>> {
+    async fn poll(&mut self, pollables: Vec<Resource<Pollable>>) -> anyhow::Result<Vec<u32>> {
         if pollables.len() > u32::MAX as usize {
             anyhow::bail!("poll called with more than 2^32 pollables");
         }

--- a/crates/durable-runtime/src/plugin/wasi/io.rs
+++ b/crates/durable-runtime/src/plugin/wasi/io.rs
@@ -74,10 +74,7 @@ impl wasi::io::streams::HostInputStream for Task {
         Ok(Err(StreamError::Closed))
     }
 
-    async fn subscribe(
-        &mut self,
-        _: Resource<InputStream>,
-    ) -> anyhow::Result<Resource<Pollable>> {
+    async fn subscribe(&mut self, _: Resource<InputStream>) -> anyhow::Result<Resource<Pollable>> {
         Ok(Resource::new_own(u32::MAX))
     }
 
@@ -141,10 +138,7 @@ impl wasi::io::streams::HostOutputStream for Task {
         self.flush(stream).await
     }
 
-    async fn subscribe(
-        &mut self,
-        _: Resource<OutputStream>,
-    ) -> anyhow::Result<Resource<Pollable>> {
+    async fn subscribe(&mut self, _: Resource<OutputStream>) -> anyhow::Result<Resource<Pollable>> {
         Ok(Resource::new_own(u32::MAX))
     }
 

--- a/crates/durable-runtime/src/plugin/wasi/random.rs
+++ b/crates/durable-runtime/src/plugin/wasi/random.rs
@@ -5,7 +5,7 @@ use crate::bindings::wasi;
 use crate::task::{Task, TransactionOptions};
 
 impl wasi::random::random::Host for Task {
-    async fn get_random_bytes(&mut self, len: u64) -> wasmtime::Result<Vec<u8>> {
+    async fn get_random_bytes(&mut self, len: u64) -> anyhow::Result<Vec<u8>> {
         let config = self.state.config();
         if len as usize > config.max_returned_buffer_len {
             anyhow::bail!("get-random-bytes requested more bytes than permitted by config");
@@ -27,7 +27,7 @@ impl wasi::random::random::Host for Task {
             .await
     }
 
-    async fn get_random_u64(&mut self) -> wasmtime::Result<u64> {
+    async fn get_random_u64(&mut self) -> anyhow::Result<u64> {
         let options = TransactionOptions::new("wasi:random/random.get-random-u64");
         self.state
             .maybe_do_transaction_sync(options, move |_| {
@@ -42,7 +42,7 @@ impl wasi::random::random::Host for Task {
 }
 
 impl wasi::random::insecure::Host for Task {
-    async fn get_insecure_random_bytes(&mut self, len: u64) -> wasmtime::Result<Vec<u8>> {
+    async fn get_insecure_random_bytes(&mut self, len: u64) -> anyhow::Result<Vec<u8>> {
         let config = self.state.config();
         if len as usize > config.max_returned_buffer_len {
             anyhow::bail!(
@@ -60,7 +60,7 @@ impl wasi::random::insecure::Host for Task {
             .await
     }
 
-    async fn get_insecure_random_u64(&mut self) -> wasmtime::Result<u64> {
+    async fn get_insecure_random_u64(&mut self) -> anyhow::Result<u64> {
         let options = TransactionOptions::new("wasi:random/random.get-insecure-random-u64");
         self.state
             .maybe_do_transaction_sync(options, move |_| Ok(rand::rng().next_u64()))
@@ -69,7 +69,7 @@ impl wasi::random::insecure::Host for Task {
 }
 
 impl wasi::random::insecure_seed::Host for Task {
-    async fn insecure_seed(&mut self) -> wasmtime::Result<(u64, u64)> {
+    async fn insecure_seed(&mut self) -> anyhow::Result<(u64, u64)> {
         // This needs to be something that is consistent between hosts so we
         // implement it by hashing the task name and task id using a hasher that
         // is not random (so not the one in std).

--- a/crates/durable-runtime/src/resource.rs
+++ b/crates/durable-runtime/src/resource.rs
@@ -47,7 +47,7 @@ impl Resources {
     /// This will return an error if:
     /// - there is no resource with the provided resource id,
     /// - the resource was created in a transaction other than the current one.
-    pub fn get<R>(&self, res: Resource<R>) -> wasmtime::Result<&R::Data>
+    pub fn get<R>(&self, res: Resource<R>) -> anyhow::Result<&R::Data>
     where
         R: Resourceable,
     {
@@ -80,7 +80,7 @@ impl Resources {
     /// This will return an error if:
     /// - there is no resource with the provided resource id,
     /// - the resource was created in a transaction other than the current one.
-    pub fn get_mut<R>(&mut self, res: Resource<R>) -> wasmtime::Result<&mut R::Data>
+    pub fn get_mut<R>(&mut self, res: Resource<R>) -> anyhow::Result<&mut R::Data>
     where
         R: Resourceable,
     {
@@ -104,7 +104,7 @@ impl Resources {
         Ok(&mut entry.data)
     }
 
-    pub fn get_txn<R>(&mut self, res: Resource<R>) -> wasmtime::Result<Option<i32>>
+    pub fn get_txn<R>(&mut self, res: Resource<R>) -> anyhow::Result<Option<i32>>
     where
         R: Resourceable,
     {
@@ -128,7 +128,7 @@ impl Resources {
         Ok(entry.txn)
     }
 
-    pub fn insert<R>(&mut self, data: R::Data) -> wasmtime::Result<Resource<R>>
+    pub fn insert<R>(&mut self, data: R::Data) -> anyhow::Result<Resource<R>>
     where
         R: Resourceable,
     {
@@ -151,7 +151,7 @@ impl Resources {
         Ok(Resource::new_own(index))
     }
 
-    pub fn remove<R>(&mut self, res: Resource<R>) -> wasmtime::Result<R::Data>
+    pub fn remove<R>(&mut self, res: Resource<R>) -> anyhow::Result<R::Data>
     where
         R: Resourceable,
     {

--- a/crates/durable-runtime/src/worker.rs
+++ b/crates/durable-runtime/src/worker.rs
@@ -261,15 +261,13 @@ impl WorkerBuilder {
             metrics: SharedMetrics::new(),
         });
 
-        let mut config = self.wasmtime_config.unwrap_or_else(|| {
+        let config = self.wasmtime_config.unwrap_or_else(|| {
             let mut config = wasmtime::Config::new();
             config.wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Enable);
             config.cranelift_opt_level(wasmtime::OptLevel::Speed);
             config.debug_info(true);
             config
         });
-
-        config.async_support(true);
 
         let engine = wasmtime::Engine::new(&config)?;
         let event_source = match self.event_source {
@@ -1313,7 +1311,8 @@ impl Worker {
                     move || Component::new(&engine, &wasm)
                 })
                 .await
-                .context("component compilation panicked")??;
+                .context("component compilation panicked")?
+                .map_err(anyhow::Error::from)?;
 
                 let elapsed = start.elapsed();
                 tracing::debug!(
@@ -1358,6 +1357,7 @@ impl Worker {
         for plugin in shared.plugins.iter() {
             plugin
                 .setup(&mut linker, &mut task)
+                .map_err(anyhow::Error::from)
                 .with_context(|| format!("failed to set up plugin `{}`", plugin.name()))?;
         }
 
@@ -1369,6 +1369,7 @@ impl Worker {
 
         let instance = Imports::instantiate_async(&mut store, &component, &linker)
             .await
+            .map_err(anyhow::Error::from)
             .context("failed to instantiate the wasm component")?;
         let guest = instance.wasi_cli_run();
 
@@ -1377,6 +1378,7 @@ impl Worker {
             Ok(Ok(())) => TaskStatus::ExitSuccess,
             Ok(Err(())) => TaskStatus::ExitFailure,
             Err(e) => {
+                let e: anyhow::Error = e.into();
                 if let Some(exit) = as_task_exit(&e) {
                     exit
                 } else {


### PR DESCRIPTION
This PR updates the plugin implementations to use `anyhow::Result` instead of `wasmtime::Result` for their host function return types. This change improves error handling consistency across the codebase by using the standard `anyhow` error type throughout.

## Key Changes

- **SQL Plugin**: Updated all `HostTypeInfo` and `HostValue` trait implementations to return `anyhow::Result` instead of `wasmtime::Result` (~180 method signatures)
- **WASI Plugins**: Updated filesystem, I/O, CLI, clocks, and random implementations to use `anyhow::Result`
- **HTTP Plugin**: Updated `HostHttpError2` and `HostHttpRequest2` trait implementations to return `anyhow::Result`
- **Notify Plugin**: Updated notification blocking methods to return `anyhow::Result`
- **Resource Management**: Updated `Resources` trait methods (`get`, `get_mut`, `get_txn`) to return `anyhow::Result`
- **Bindgen Configuration**: Added `anyhow: true` to the `bindgen!` macro configuration in `lib.rs` to enable anyhow support
- **Worker Configuration**: Removed the `config.async_support(true)` call from `WorkerBuilder` as it's no longer needed

## Implementation Details

The change leverages the `anyhow` crate's integration with wasmtime's component model, allowing host functions to return `anyhow::Result` which is automatically converted to the appropriate trap/error representation. This provides better error context and consistency with the rest of the codebase's error handling patterns.

https://claude.ai/code/session_017QXVDsinAdu6SjX7QZPZ26