### PR TITLE
Update wit-bindgen from 0.51 to 0.57

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1024,8 +1024,8 @@ dependencies = [
  "anyhow",
  "prettyplease",
  "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
+ "wit-bindgen-core 0.57.1",
+ "wit-bindgen-rust 0.57.1",
 ]
 
 [[package]]
@@ -4251,6 +4251,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b6733b8b91d010a6ac5b0fb237dc46a19650bc4c67db66857e2e787d437204"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.247.0",
+]
+
+[[package]]
+name = "wasm-encoder"
 version = "0.248.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
@@ -4282,6 +4292,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-metadata"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665fe59e56cc9b419ca6fcca56673e3421d1a5011e3b65caf6b726fd9e041d10"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder 0.247.0",
+ "wasmparser 0.247.0",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4302,6 +4324,18 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6fb4c2bee46c5ea4d40f8cdb5c131725cd976718ec56f1c8e82fbde5fa2a80"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "semver",
 ]
@@ -5118,6 +5152,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-core"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02dee27a2dc20d1008016c742ec9fc6ea498492994ba3750be7454cbc97ff04c"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser 0.247.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5134,9 +5179,25 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
+ "wasm-metadata 0.244.0",
+ "wit-bindgen-core 0.51.0",
+ "wit-component 0.244.0",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5007dae772945b7a5003d69d90a3a4a78929d41f19d004e980c4259a6af4484"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata 0.247.0",
+ "wit-bindgen-core 0.57.1",
+ "wit-component 0.247.0",
 ]
 
 [[package]]
@@ -5150,8 +5211,8 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
+ "wit-bindgen-core 0.51.0",
+ "wit-bindgen-rust 0.51.0",
 ]
 
 [[package]]
@@ -5168,9 +5229,28 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.244.0",
- "wasm-metadata",
+ "wasm-metadata 0.244.0",
  "wasmparser 0.244.0",
  "wit-parser 0.244.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d567162a6b9843080e5e0053f696623ff694bae8ae017c9ec536d1873bbe3d8"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.247.0",
+ "wasm-metadata 0.247.0",
+ "wasmparser 0.247.0",
+ "wit-parser 0.247.0",
 ]
 
 [[package]]
@@ -5189,6 +5269,25 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.244.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.247.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ffe4064318cdf3c08cb99343b44c039fcefe61ccdf58aa9975285f13d74d1fc"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.1",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.247.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,8 @@ durable-runtime = { version = "0.8.0", registry = "iop-systems", path = "crates/
 durable-bindgen = { version = "0.1.3", registry = "iop-systems", path = "crates/durable-bindgen" }
 
 wasmtime         = { version = "45.0", features = ["anyhow"] }
-wit-bindgen-core = { version = "0.51.0" }
-wit-bindgen-rust = { version = "0.51.0" }
+wit-bindgen-core = { version = "0.57.1" }
+wit-bindgen-rust = { version = "0.57.1" }
 wit-bindgen-rt   = { version = "0.44.0" }
 
 [workspace.dependencies.durable-sqlx-macros]

--- a/crates/durable-bindgen/src/lib.rs
+++ b/crates/durable-bindgen/src/lib.rs
@@ -61,7 +61,7 @@ fn _generate(source: &Path, out: &Path, world: &str, options: Options) -> anyhow
     }
 
     let mut files = Files::default();
-    generator.generate(&resolve, world, &mut files)?;
+    generator.generate(&mut resolve, world, &mut files)?;
 
     let (_, src) = files.iter().next().unwrap();
     let src = std::str::from_utf8(src).unwrap();

--- a/crates/durable-core/src/bindings.rs
+++ b/crates/durable-core/src/bindings.rs
@@ -301,7 +301,7 @@ pub mod durable {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for NotifyError {}
+            impl ::core::error::Error for NotifyError {}
             #[allow(unused_unsafe, clippy::all)]
             /// Attempt to read the next available notification, if there is one.
             /// notification: func() -> option<event>;
@@ -655,7 +655,7 @@ pub mod wasi {
 }
 #[rustfmt::skip]
 mod _rt {
-    #![allow(dead_code, clippy::all)]
+    #![allow(dead_code, unused_imports, clippy::all)]
     pub use alloc_crate::string::String;
     pub use alloc_crate::vec::Vec;
     pub unsafe fn string_lift(bytes: Vec<u8>) -> String {
@@ -700,7 +700,7 @@ mod _rt {
 #[rustfmt::skip]
 #[cfg(target_arch = "wasm32")]
 #[unsafe(
-    link_section = "component-type:wit-bindgen:0.44.0:durable:core@2.7.0:import-core:encoded world"
+    link_section = "component-type:wit-bindgen:0.57.1:durable:core@2.7.0:import-core:encoded world"
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
@@ -721,7 +721,7 @@ w\0\x07\x04\0\x1dnotification-blocking-timeout\x01\x08\x01j\0\x01\x05\x01@\x03\x
 taskx\x05events\x04datas\0\x09\x04\0\x06notify\x01\x0a\x03\0\x19durable:core/not\
 ify@2.7.0\x05\x03\x04\0\x1edurable:core/import-core@2.7.0\x04\0\x0b\x11\x01\0\x0b\
 import-core\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-component\x07\
-0.236.1\x10wit-bindgen-rust\x060.44.0";
+0.247.0\x10wit-bindgen-rust\x060.57.1";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/crates/durable-http/src/bindings.rs
+++ b/crates/durable-http/src/bindings.rs
@@ -124,7 +124,7 @@ pub mod durable {
                     write!(f, "{:?}", self)
                 }
             }
-            impl std::error::Error for HttpError {}
+            impl ::core::error::Error for HttpError {}
             #[derive(Debug)]
             #[repr(transparent)]
             pub struct HttpError2 {
@@ -374,7 +374,9 @@ pub mod durable {
                                         let len21 = l20;
                                         HttpHeaderResult {
                                             name: _rt::string_lift(bytes18),
-                                            value: _rt::Vec::from_raw_parts(l19.cast(), len21, len21),
+                                            value: <_ as From<
+                                                _rt::Vec<_>,
+                                            >>::from(_rt::Vec::from_raw_parts(l19.cast(), len21, len21)),
                                         }
                                     };
                                     result22.push(e22);
@@ -394,7 +396,9 @@ pub mod durable {
                                 HttpResponse {
                                     status: l13 as u16,
                                     headers: result22,
-                                    body: _rt::Vec::from_raw_parts(l23.cast(), len25, len25),
+                                    body: <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l23.cast(), len25, len25)),
                                 }
                             };
                             Ok(e)
@@ -946,7 +950,9 @@ pub mod durable {
                                         let len11 = l10;
                                         HttpHeaderResult {
                                             name: _rt::string_lift(bytes8),
-                                            value: _rt::Vec::from_raw_parts(l9.cast(), len11, len11),
+                                            value: <_ as From<
+                                                _rt::Vec<_>,
+                                            >>::from(_rt::Vec::from_raw_parts(l9.cast(), len11, len11)),
                                         }
                                     };
                                     result12.push(e12);
@@ -966,7 +972,9 @@ pub mod durable {
                                 HttpResponse {
                                     status: l3 as u16,
                                     headers: result12,
-                                    body: _rt::Vec::from_raw_parts(l13.cast(), len15, len15),
+                                    body: <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l13.cast(), len15, len15)),
                                 }
                             };
                             Ok(e)
@@ -990,7 +998,7 @@ pub mod durable {
 }
 #[rustfmt::skip]
 mod _rt {
-    #![allow(dead_code, clippy::all)]
+    #![allow(dead_code, unused_imports, clippy::all)]
     pub use alloc_crate::string::String;
     pub use alloc_crate::vec::Vec;
     use core::fmt;
@@ -1130,7 +1138,7 @@ mod _rt {
 #[rustfmt::skip]
 #[cfg(target_arch = "wasm32")]
 #[unsafe(
-    link_section = "component-type:wit-bindgen:0.44.0:durable:core@2.7.0:import-http:encoded world"
+    link_section = "component-type:wit-bindgen:0.57.1:durable:core@2.7.0:import-http:encoded world"
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
@@ -1157,7 +1165,7 @@ lf\x15\x07headers\x03\0\x16\x04\0![method]http-request2.set-headers\x01\x19\x01@
 j\x01\x09\x01\x12\x01@\x01\x07request\x11\0\x1e\x04\0\x06fetch2\x01\x1f\x03\0\x17\
 durable:core/http@2.7.0\x05\0\x04\0\x1edurable:core/import-http@2.7.0\x04\0\x0b\x11\
 \x01\0\x0bimport-http\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0dwit-com\
-ponent\x070.236.1\x10wit-bindgen-rust\x060.44.0";
+ponent\x070.247.0\x10wit-bindgen-rust\x060.57.1";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {

--- a/crates/durable-sqlx/src/bindings.rs
+++ b/crates/durable-sqlx/src/bindings.rs
@@ -1910,7 +1910,9 @@ pub mod durable {
                                         .add(2 * ::core::mem::size_of::<*const u8>())
                                         .cast::<usize>();
                                     let len5 = l4;
-                                    _rt::Vec::from_raw_parts(l3.cast(), len5, len5)
+                                    <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l3.cast(), len5, len5))
                                 };
                                 Some(e)
                             }
@@ -2269,7 +2271,9 @@ pub mod durable {
                                         .add(2 * ::core::mem::size_of::<*const u8>())
                                         .cast::<usize>();
                                     let len5 = l4;
-                                    _rt::Vec::from_raw_parts(l3.cast(), len5, len5)
+                                    <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l3.cast(), len5, len5))
                                 };
                                 Some(e)
                             }
@@ -2319,7 +2323,9 @@ pub mod durable {
                                         .add(2 * ::core::mem::size_of::<*const u8>())
                                         .cast::<usize>();
                                     let len5 = l4;
-                                    _rt::Vec::from_raw_parts(l3.cast(), len5, len5)
+                                    <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l3.cast(), len5, len5))
                                 };
                                 Some(e)
                             }
@@ -2369,7 +2375,9 @@ pub mod durable {
                                         .add(2 * ::core::mem::size_of::<*const u8>())
                                         .cast::<usize>();
                                     let len5 = l4;
-                                    _rt::Vec::from_raw_parts(l3.cast(), len5, len5)
+                                    <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l3.cast(), len5, len5))
                                 };
                                 Some(e)
                             }
@@ -2419,7 +2427,9 @@ pub mod durable {
                                         .add(2 * ::core::mem::size_of::<*const u8>())
                                         .cast::<usize>();
                                     let len5 = l4;
-                                    _rt::Vec::from_raw_parts(l3.cast(), len5, len5)
+                                    <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l3.cast(), len5, len5))
                                 };
                                 Some(e)
                             }
@@ -2469,7 +2479,9 @@ pub mod durable {
                                         .add(2 * ::core::mem::size_of::<*const u8>())
                                         .cast::<usize>();
                                     let len5 = l4;
-                                    _rt::Vec::from_raw_parts(l3.cast(), len5, len5)
+                                    <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l3.cast(), len5, len5))
                                 };
                                 Some(e)
                             }
@@ -2519,7 +2531,9 @@ pub mod durable {
                                         .add(2 * ::core::mem::size_of::<*const u8>())
                                         .cast::<usize>();
                                     let len5 = l4;
-                                    _rt::Vec::from_raw_parts(l3.cast(), len5, len5)
+                                    <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l3.cast(), len5, len5))
                                 };
                                 Some(e)
                             }
@@ -2655,7 +2669,9 @@ pub mod durable {
                                                 .add(::core::mem::size_of::<*const u8>())
                                                 .cast::<usize>();
                                             let len7 = l6;
-                                            _rt::Vec::from_raw_parts(l5.cast(), len7, len7)
+                                            <_ as From<
+                                                _rt::Vec<_>,
+                                            >>::from(_rt::Vec::from_raw_parts(l5.cast(), len7, len7))
                                         };
                                         result8.push(e8);
                                     }
@@ -2714,7 +2730,9 @@ pub mod durable {
                                         .add(2 * ::core::mem::size_of::<*const u8>())
                                         .cast::<usize>();
                                     let len5 = l4;
-                                    _rt::Vec::from_raw_parts(l3.cast(), len5, len5)
+                                    <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l3.cast(), len5, len5))
                                 };
                                 Some(e)
                             }
@@ -2764,7 +2782,9 @@ pub mod durable {
                                         .add(2 * ::core::mem::size_of::<*const u8>())
                                         .cast::<usize>();
                                     let len5 = l4;
-                                    _rt::Vec::from_raw_parts(l3.cast(), len5, len5)
+                                    <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l3.cast(), len5, len5))
                                 };
                                 Some(e)
                             }
@@ -2814,7 +2834,9 @@ pub mod durable {
                                         .add(2 * ::core::mem::size_of::<*const u8>())
                                         .cast::<usize>();
                                     let len5 = l4;
-                                    _rt::Vec::from_raw_parts(l3.cast(), len5, len5)
+                                    <_ as From<
+                                        _rt::Vec<_>,
+                                    >>::from(_rt::Vec::from_raw_parts(l3.cast(), len5, len5))
                                 };
                                 Some(e)
                             }
@@ -4320,7 +4342,7 @@ pub mod durable {
 }
 #[rustfmt::skip]
 mod _rt {
-    #![allow(dead_code, clippy::all)]
+    #![allow(dead_code, unused_imports, clippy::all)]
     use core::fmt;
     use core::marker;
     use core::sync::atomic::{AtomicU32, Ordering::Relaxed};
@@ -4553,7 +4575,7 @@ mod _rt {
 #[rustfmt::skip]
 #[cfg(target_arch = "wasm32")]
 #[unsafe(
-    link_section = "component-type:wit-bindgen:0.44.0:durable:core@2.7.0:import-sql:encoded world"
+    link_section = "component-type:wit-bindgen:0.57.1:durable:core@2.7.0:import-sql:encoded world"
 )]
 #[doc(hidden)]
 #[allow(clippy::octal_escapes)]
@@ -4655,7 +4677,7 @@ p\x0f\x01@\x03\x03sqls\x06params\x92\x01\x07options\x18\x01\0\x04\0\x05query\x01
 \x93\x01\x01j\x01\x16\x01!\x01k\x94\x01\x01@\0\0\x95\x01\x04\0\x05fetch\x01\x96\x01\
 \x03\0\x16durable:core/sql@2.7.0\x05\0\x04\0\x1ddurable:core/import-sql@2.7.0\x04\
 \0\x0b\x10\x01\0\x0aimport-sql\x03\0\0\0G\x09producers\x01\x0cprocessed-by\x02\x0d\
-wit-component\x070.236.1\x10wit-bindgen-rust\x060.44.0";
+wit-component\x070.247.0\x10wit-bindgen-rust\x060.57.1";
 #[inline(never)]
 #[doc(hidden)]
 pub fn __link_custom_section_describing_imports() {


### PR DESCRIPTION
## Summary

Bumps the guest-side `wit-bindgen` codegen crates to the latest `0.57.1`. This is independent toolchain maintenance, split out from the wasmtime 42→45 upgrade (#102) to keep each change single-purpose and bisectable.

## Changes

- `wit-bindgen-core` / `wit-bindgen-rust`: **0.51.0 → 0.57.1**
- `wit-bindgen-rt`: left at **0.44.0** (already its latest stable release; it tracks a separate version line)
- **One API fix** in `durable-bindgen`: `WorldGenerator::generate` now takes `&mut Resolve` instead of `&Resolve`
- Regenerated the checked-in `bindings.rs` for `durable-core`, `durable-http`, and `durable-sqlx`

## Bindings diff is benign

The regenerated bindings differ only cosmetically:
- `std::error::Error` → `::core::error::Error` (no_std-friendly)
- `Vec::from_raw_parts(...)` wrapped in an identity `<_ as From<Vec<_>>>::from(...)` (codegen generalization, functionally identical)
- Updated producer version strings in the encoded component-type sections (`wit-bindgen-rust` `0.44.0`→`0.57.1`, `wit-component` `0.236.1`→`0.247.0`)

## Validation

- `durable-bindgen` / `xtask` compile against 0.57
- Guest crates build for `wasm32-wasip1`; host workspace builds `--locked`; `rustfmt` clean
- Full test suite green locally: **44/44 passed** (including the integration tests that execute the WASM workflows built from the regenerated bindings)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E8WGJMBb3LysnVrio2ZeA8)_