### PR TITLE
chore(deps): bump ctor 0.6 -> 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,19 +848,13 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.6.3"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
+checksum = "01334b89b69ff726750c5ce5073fc8bd860e99aa9a8fc5ca11b04730e3aee97a"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "link-section",
+ "linktime-proc-macro",
 ]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
@@ -978,21 +972,6 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
-
-[[package]]
-name = "dtor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -2152,6 +2131,18 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "link-section"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2b1dd6fe32e55c0fc0ea9493aa57459ca3cf4ff3c857c7d0302290150da6e4f"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
 
 [[package]]
 name = "linux-raw-sys"

--- a/crates/durable-test/Cargo.toml
+++ b/crates/durable-test/Cargo.toml
@@ -17,5 +17,5 @@ sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls"] }
 tokio = { version = "1.50", features = ["full", "macros"] }
 wasmtime = { workspace = true }
 futures = "0.3.32"
-ctor = "0.6.3"
+ctor = "1.0"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt"] }

--- a/crates/durable-test/src/lib.rs
+++ b/crates/durable-test/src/lib.rs
@@ -121,7 +121,7 @@ impl Drop for WorkerShutdownGuard {
     }
 }
 
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn setup_tracing() {
     use tracing_subscriber::prelude::*;
 


### PR DESCRIPTION
## What

Bumps `ctor` 0.6.3 → 1.0 in `durable-test`.

ctor 1.0 now requires constructor functions to be explicitly marked `unsafe` — they run before `main()`, outside the normal Rust runtime, so the macro enforces an explicit acknowledgement. The single usage is updated per the compiler's instruction:

```rust
-#[ctor::ctor]
+#[ctor::ctor(unsafe)]
 fn setup_tracing() { ... }
```

This is test-harness-only setup (initializes the tracing subscriber); no production code path is affected.

## Verification

`cargo check -p durable-test --all-features --locked` ✅

https://claude.ai/code/session_01KN3PaeQ1pFq1B3uReMqHjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KN3PaeQ1pFq1B3uReMqHjp)_