### PR TITLE
chore(deps): bump wasmparser 0.227 -> 0.251

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,7 +1052,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
- "wasmparser 0.227.1",
+ "wasmparser 0.251.0",
  "weak-table",
 ]
 
@@ -1610,7 +1610,6 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.1.5",
- "serde",
 ]
 
 [[package]]
@@ -4340,19 +4339,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.227.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
@@ -4395,8 +4381,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
  "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]

--- a/crates/durable-client/Cargo.toml
+++ b/crates/durable-client/Cargo.toml
@@ -24,5 +24,5 @@ serde = "1.0.228"
 serde_json = "1.0.149"
 sha2 = "0.10.9"
 sqlx = { version = "0.8", features = ["chrono", "macros", "postgres", "runtime-tokio"] }
-wasmparser = { version = "0.227.0", features = ["validate"] }
+wasmparser = { version = "0.251.0", features = ["validate"] }
 weak-table = "0.3.2"


### PR DESCRIPTION
## What

Bumps `wasmparser` 0.227.0 → 0.251.0 in `durable-client`.

`wasmtime` 45 (used by the runtime) already pulls `wasmparser` 0.251 transitively, so this bumps durable-client's **direct** dependency to match and **dedupes the two copies** out of the lockfile (net lock change: just removing the old 0.227.1 entry).

The APIs used here — `Validator::new_with_features` / `validate_all`, `WasmFeatures` (`default`, `remove(THREADS)`), `Parser::is_component`, `BinaryReaderError` — are unchanged, so **no code changes are required**.

## Verification

`cargo check -p durable-client --all-features --locked` ✅

https://claude.ai/code/session_01KN3PaeQ1pFq1B3uReMqHjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KN3PaeQ1pFq1B3uReMqHjp)_