### PR TITLE
chore(deps): bump tabled 0.20 -> 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,9 +2406,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "papergrid"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
 dependencies = [
  "bytecount",
  "fnv",
@@ -3623,9 +3623,9 @@ dependencies = [
 
 [[package]]
 name = "tabled"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
 dependencies = [
  "papergrid",
  "tabled_derive",

--- a/crates/durable-cli/Cargo.toml
+++ b/crates/durable-cli/Cargo.toml
@@ -21,7 +21,7 @@ futures-util = "0.3.32"
 log = "0.4.29"
 serde = "1.0.228"
 serde_json = { version = "1.0.149", features = ["raw_value"] }
-tabled = "0.20.0"
+tabled = "0.21.0"
 tokio = { version = "1.50.0", features = ["full"] }
 tracing-subscriber = { version = "0.3.23", features = ["fmt", "env-filter"] }
 


### PR DESCRIPTION
## What

Bumps `tabled` 0.20.0 → 0.21.0 in `durable-cli`.

The only `tabled` usage is the event-listing table in `durable-cli` (`events.rs`). The settings API used there (`Modify` / `Segment` / `Alignment` / `AlignmentStrategy` / `Style` / `Margin` / `Padding` and the `#[derive(Tabled)]`) is unchanged in 0.21, so **no code changes are required**. Pulls `papergrid` 0.17 → 0.18.

> Note: the other `Table::new(...)` references in the codebase (migrate/runtime/xtask) are sqlx migration tables, unrelated to this crate.

## Verification

`cargo check -p durable-cli --all-features --locked` ✅

https://claude.ai/code/session_01KN3PaeQ1pFq1B3uReMqHjp

---
_Generated by [Claude Code](https://claude.ai/code/session_01KN3PaeQ1pFq1B3uReMqHjp)_