### PR TITLE
Enable serde feature for ipnetwork dependency

### DIFF
--- a/crates/durable-runtime/Cargo.toml
+++ b/crates/durable-runtime/Cargo.toml
@@ -29,7 +29,7 @@ chrono = { version = "0.4.44", features = ["serde"] }
 clap = { version = "4.6", optional = true, features = ["derive", "env"] }
 console-subscriber = { version = "0.5.0", optional = true }
 derive_setters = "0.1.9"
-ipnetwork = "0.21.0"
+ipnetwork = { version = "0.21.0", features = ["serde"] }
 futures-concurrency = "7.7.1"
 futures-util = "0.3.32"
 getrandom = { version = "0.4.2", features = ["std"] }


### PR DESCRIPTION
## Summary
Enable the `serde` feature for the `ipnetwork` crate to support serialization and deserialization of network types.

## Changes
- Updated `ipnetwork` dependency to explicitly enable the `serde` feature, allowing network types to be serialized and deserialized

## Details
This change enables serialization support for IP network types used throughout the durable-runtime crate, which is necessary for any code that needs to serialize network configuration or data structures containing IP network information.

https://claude.ai/code/session_01WbWc3V1fbNfmjAvfGcrpkg