### PR TITLE
Fix slice reference encoding for array parameters

### DIFF
--- a/crates/durable-sqlx/src/driver/types/mod.rs
+++ b/crates/durable-sqlx/src/driver/types/mod.rs
@@ -57,8 +57,11 @@ macro_rules! forward_encode_deref {
 }
 macro_rules! forward_slice_encode_deref {
     ($elem:ty) => {
-        // `&T` and `Cow<'_, T>` are covered by blanket `Encode` impls in sqlx 0.9,
-        // so we only forward for the wrappers without such blanket impls.
+        // sqlx 0.9's blanket `impl Encode for &T` requires `T: Sized`, so it does
+        // *not* cover `&[$elem]` (the pointee `[$elem]` is unsized). Forward it here
+        // explicitly so slice references stay bindable. `Cow<'_, [$elem]>` is covered
+        // by a blanket `Encode` impl in sqlx 0.9.
+        forward_encode_deref!(&'_ [$elem] => [$elem]);
         forward_encode_deref!(Vec<$elem> => [$elem]);
         forward_encode_deref!(Box<[$elem]> => [$elem]);
     }
@@ -117,4 +120,32 @@ where
     T: sqlx::Encode<'q, Durable> + ?Sized,
 {
     value.encode_by_ref(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Durable;
+
+    /// Regression test for #114: binding a `&[T]` slice reference as an array
+    /// parameter must compile for every element type declared via the slice
+    /// macros, matching the hand-written `uuid` impls. sqlx 0.9's blanket
+    /// `impl Encode for &T` requires `T: Sized`, so it does not cover `&[T]`
+    /// (the pointee `[T]` is unsized) — the forwarding impls are what make
+    /// these bindable.
+    fn assert_encode<'q, T: sqlx::Encode<'q, Durable>>() {}
+
+    #[test]
+    fn slice_refs_implement_encode() {
+        assert_encode::<&[i8]>();
+        assert_encode::<&[i16]>();
+        assert_encode::<&[i32]>();
+        assert_encode::<&[i64]>();
+        assert_encode::<&[f32]>();
+        assert_encode::<&[f64]>();
+        assert_encode::<&[bool]>();
+        assert_encode::<&[&str]>();
+        assert_encode::<&[String]>();
+        #[cfg(feature = "uuid")]
+        assert_encode::<&[::uuid::Uuid]>();
+    }
 }


### PR DESCRIPTION
## Summary
This PR fixes an issue where slice references (`&[T]`) could not be bound as array parameters in SQL queries. The fix involves explicitly forwarding the `Encode` implementation for slice references and adding regression tests to ensure the fix works across all supported element types.

## Key Changes
- **Updated `forward_slice_encode_deref!` macro**: Added explicit forwarding for `&'_ [$elem]` slice references. This is necessary because sqlx 0.9's blanket `impl Encode for &T` requires `T: Sized`, which doesn't cover unsized slice types `&[T]`.
- **Improved documentation**: Clarified the comment explaining why slice references need explicit forwarding while `Cow<'_, [$elem]>` is already covered by blanket impls.
- **Added regression tests**: Introduced a new test module that verifies `&[T]` implements `Encode` for all supported element types (i8, i16, i32, i64, f32, f64, bool, &str, String, and uuid::Uuid when the uuid feature is enabled).

## Implementation Details
The fix leverages the existing `forward_encode_deref!` macro to create the necessary `Encode` implementations for slice references. The test uses a compile-time assertion pattern (`assert_encode::<T>()`) to ensure that the trait bounds are satisfied, which will catch any regressions if the forwarding implementations are accidentally removed or broken.

https://claude.ai/code/session_0175YJdZtGPi5MhpF6HYErzC